### PR TITLE
Update package.xml to fix 404

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="vivien.henry@inductivebrain.fr">Vivien Henry</maintainer>
   <license file="LICENSE">LGPLv3</license>
   <url branch="main" type="repository">https://github.com/lukh/frameforge.git</url>
-  <url type="readme">https://github.com/lukh/frameforge.git/-/raw/main/README.md</url>
+  <url type="readme">https://github.com/lukh/frameforge/blob/main/README.md</url>
   <icon>freecad/frameforge/resources/icons/metalwb.svg</icon>
 
   <content>


### PR DESCRIPTION
<img width="818" height="176" alt="image" src="https://github.com/user-attachments/assets/e184abcc-e95d-4864-a853-7f2c3e36a163" />

I *think* this should work, looked at another add-on to see it's done with a (working) readme in addon manager.

It's hard to test this since I do not have a test setup for addon manager at hand, but I hope it is correct.