### PR TITLE
Properly handle misalignment when calculating end mitre (#35)

### DIFF
--- a/freecad/frameforge/create_bom.py
+++ b/freecad/frameforge/create_bom.py
@@ -311,10 +311,26 @@ def traverse_assembly(profiles_data, links_data, obj, parent="", full_parent_pat
         profiles_data.append(p)
 
     elif is_link(obj):
-        links_data.append({"parent": parent, "label": obj.Label, "part": obj.LinkedObject.Label, "quantity": "1", "price":getattr(obj.LinkedObject, "Price", "N/A")})
+        links_data.append(
+            {
+                "parent": parent,
+                "label": obj.Label,
+                "part": obj.LinkedObject.Label,
+                "quantity": "1",
+                "price": getattr(obj.LinkedObject, "Price", "N/A"),
+            }
+        )
 
     elif is_part_or_part_design(obj):
-        links_data.append({"parent": parent, "label": obj.Label, "part": obj.Label, "quantity": "1", "price":getattr(obj, "Price", "N/A")})
+        links_data.append(
+            {
+                "parent": parent,
+                "label": obj.Label,
+                "part": obj.Label,
+                "quantity": "1",
+                "price": getattr(obj, "Price", "N/A"),
+            }
+        )
 
 
 def group_profiles(profiles_data):

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -30,7 +30,7 @@ class EditProfileTaskPanel(CreateProfileTaskPanel):
         self.form_proxy.sb_radius1.setValue(self.profile.RadiusLarge)
         self.form_proxy.sb_radius2.setValue(self.profile.RadiusSmall)
         self.form_proxy.sb_length.setValue(self.profile.ProfileLength)
-        self.form_proxy.sb_weight.setValue(self.profile.ApproxWeight )
+        self.form_proxy.sb_weight.setValue(self.profile.ApproxWeight)
         try:
             self.form_proxy.sb_unitprice.setValue(self.profile.UnitPrice)
         except:

--- a/freecad/frameforge/profile.py
+++ b/freecad/frameforge/profile.py
@@ -32,7 +32,6 @@ class Profile:
 
     def set_current_pid(cls, pid):
         cls._id_counter = pid
-    
 
     def __init__(
         self,
@@ -151,7 +150,6 @@ class Profile:
             obj.LinearWeight * init_len / 1000
         )
         obj.setEditorMode("ApproxWeight", 1)  # user doesn't change !
-
 
         obj.addProperty("App::PropertyFloat", "UnitPrice", "Base", "Approximate linear price").UnitPrice = (
             init_unit_price
@@ -1033,8 +1031,6 @@ class Profile:
         obj.positionBySupport()
         obj.recompute()
 
-
-
     def run_compatibility_migrations(self, obj):
         # add Family atttribute
         if not hasattr(obj, "Family"):
@@ -1046,13 +1042,13 @@ class Profile:
                 "",
             ).Family = self.fam
 
-
         # add LinearWeight attribute (<= 0.1.7)
         if not hasattr(obj, "LinearWeight"):
             App.Console.PrintMessage(f"Frameforge::object migration : adding LinearWeight ({self.WM}) to {obj.Label}\n")
-            obj.addProperty("App::PropertyFloat", "LinearWeight", "Base", "Linear weight in kg/m").LinearWeight = self.WM
+            obj.addProperty("App::PropertyFloat", "LinearWeight", "Base", "Linear weight in kg/m").LinearWeight = (
+                self.WM
+            )
             obj.setEditorMode("ApproxWeight", 1)
-
 
         # add prices
         if not hasattr(obj, "UnitPrice"):
@@ -1060,7 +1056,7 @@ class Profile:
         if not hasattr(obj, "Price"):
             obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price").Price = 0.0
             obj.setEditorMode("Price", 1)
-            
+
 
 class ViewProviderProfile:
     def __init__(self, obj):

--- a/freecad/frameforge/trimmed_profile.py
+++ b/freecad/frameforge/trimmed_profile.py
@@ -116,6 +116,8 @@ class TrimmedProfile:
                     p1 = end1
                     p2 = start1
                     p3 = start2
+                else:
+                    raise RuntimeError("End Miter: edges not aligned. Ensure they meet at a common endpoint.")
 
                 normal = Part.Plane(p1, p2, p3).toShape().normalAt(0, 0)
                 cutplane = Part.makePlane(10, 10, p1, vec1, normal)


### PR DESCRIPTION
Show information error message when mitread partd miasligned instead of "p1 variable not defined"