### PR TITLE
Reworked profile placement UI and options (develop branch)

### DIFF
--- a/freecad/frameforge/InitGui.py
+++ b/freecad/frameforge/InitGui.py
@@ -192,7 +192,13 @@ class FrameForge(Gui.Workbench):
 
     toolbox_part = ["FrameForge_Link", "Part_Fuse", "Part_Cut", "PartDesign_Body"]
 
-    toolbox_output = ["FrameForge_PopulateIDs", "FrameForge_ResetIDs", "FrameForge_CreateBalloons", "FrameForge_RefreshBalloons", "FrameForge_CreateBOM"]
+    toolbox_output = [
+        "FrameForge_PopulateIDs",
+        "FrameForge_ResetIDs",
+        "FrameForge_CreateBalloons",
+        "FrameForge_RefreshBalloons",
+        "FrameForge_CreateBOM",
+    ]
 
     def GetClassName(self):
         return "Gui::PythonWorkbench"
@@ -204,8 +210,8 @@ class FrameForge(Gui.Workbench):
         """
         from freecad.frameforge import (
             create_bom_tool,
-            create_edit_balloons_tool,
             create_custom_profiles_tool,
+            create_edit_balloons_tool,
             create_end_miter_tool,
             create_extruded_cutout_tool,
             create_link,
@@ -213,7 +219,7 @@ class FrameForge(Gui.Workbench):
             create_trimmed_profiles_tool,
             edit_profile_tool,
             parametric_line,
-            populate_ids_tool
+            populate_ids_tool,
         )
         from freecad.frameforge.ff_tools import translate
 

--- a/freecad/frameforge/_utils.py
+++ b/freecad/frameforge/_utils.py
@@ -74,7 +74,6 @@ def getShape(obj, prop, shape_type):
         return None
 
 
-
 def is_fusion(obj):
     if obj.TypeId == "Part::MultiFuse":
         shape = obj.Shape
@@ -120,8 +119,6 @@ def is_part_or_part_design(obj):
     return obj.TypeId.startswith(("Part::", "PartDesign::"))
 
 
-
-
 def get_profiles_and_links_from_object(profiles, links, obj):
     if is_fusion(obj):
         for child in obj.Shapes:
@@ -138,7 +135,6 @@ def get_profiles_and_links_from_object(profiles, links, obj):
             # It makes it mandatory to have visible object when generating BOM
             if child.getParentGroup() in (obj, None) and child.Visibility:
                 get_profiles_and_links_from_object(profiles, links, child)
-
 
     elif is_profile(obj):
         profiles.append(obj)
@@ -158,14 +154,13 @@ def get_profiles_and_links_from_document():
     return [o for o in doc.Objects if is_profile(o)], [o for o in doc.Objects if is_link(o)]
 
 
-
-
 # TODO move this code into TrimmedProfile ?
 def get_profile_from_trimmedbody(obj):
     if is_trimmedbody(obj):
         return get_profile_from_trimmedbody(obj.TrimmedBody)
     else:
         return obj
+
 
 # TODO move this code into TrimmedProfile ?
 def get_childrens_from_trimmedbody(obj):
@@ -199,6 +194,7 @@ def get_childrens_from_extrudedcutout(obj):
     elif is_extrudedcutout(obj):
         yield from get_childrens_from_extrudedcutout(obj.baseObject[0])
 
+
 # TODO move this code into ExtrudedCutOut ?
 def get_trimmedprofile_from_extrudedcutout(obj):
     if is_extrudedcutout(obj):
@@ -227,7 +223,6 @@ def get_trimmed_profile_all_cutting_angles(trimmed_profile):
 
     edge = resolve_edge(trimmed_profile.TrimmedBody)
     dir_vec = (edge.Vertexes[-1].Point.sub(edge.Vertexes[0].Point)).normalize()
-
 
     if trimmed_profile.TrimmedProfileType == "End Trim":
         if trimmed_profile.CutType in ["Simple fit", "Simple cut"]:
@@ -277,7 +272,6 @@ def get_trimmed_profile_all_cutting_angles(trimmed_profile):
 
     else:
         raise ValueError("Unknown TrimmedProfileType")
-    
 
     if hasattr(trimmed_profile.TrimmedBody, "TrimmedProfileType"):
         parent_profile = trimmed_profile.TrimmedBody
@@ -307,9 +301,10 @@ def length_along_normal(obj):
             target = obj.Target
             edge = doc.getObject(target[0].Name).getSubObject(target[1][0])
         else:
-            return 0.0 # TODO handle this case !!!
+            return 0.0  # TODO handle this case !!!
 
     elif is_trimmedbody(obj):
+
         def resolve_edge(link):
             target = obj.Proxy.getTarget(link)
             return doc.getObject(target[0].Name).getSubObject(target[1][0])
@@ -328,7 +323,6 @@ def length_along_normal(obj):
 
     length = max(projections) - min(projections)
     return length
-
 
 
 def get_readable_cutting_angles(ba_y, ba_x, bb_y, bb_x, *trim_cuts):

--- a/freecad/frameforge/_utils.py
+++ b/freecad/frameforge/_utils.py
@@ -286,6 +286,11 @@ def get_trimmed_profile_all_cutting_angles(trimmed_profile):
     return angles
 
 
+def normalize_anchor(val):
+    """Normalize anchor to int 0–2. Accepts bool (legacy: True→1, False→0) or int; e.g. from custom macros."""
+    if isinstance(val, bool):
+        return 1 if val else 0
+    return max(0, min(2, int(val)))
 
 
 def length_along_normal(obj):

--- a/freecad/frameforge/create_bom.py
+++ b/freecad/frameforge/create_bom.py
@@ -7,17 +7,17 @@ import FreeCAD
 import FreeCADGui as Gui
 import Part
 
-
 from freecad.frameforge._utils import (
     is_extrudedcutout,
     is_fusion,
     is_group,
+    is_link,
     is_part,
+    is_part_or_part_design,
     is_profile,
     is_trimmedbody,
-    is_link,
-    is_part_or_part_design
 )
+
 
 def traverse_assembly(profiles_data, links_data, obj, parent="", full_parent_path=False):
     p = {}
@@ -76,12 +76,28 @@ def traverse_assembly(profiles_data, links_data, obj, parent="", full_parent_pat
 
         profiles_data.append(p)
 
-
     elif is_link(obj):
-        links_data.append({"parent": parent, "ID": obj.PID, "label": obj.Label, "part": obj.LinkedObject.Label, "quantity": "1", "price":getattr(obj.LinkedObject, "Price", "N/A")})
+        links_data.append(
+            {
+                "parent": parent,
+                "ID": obj.PID,
+                "label": obj.Label,
+                "part": obj.LinkedObject.Label,
+                "quantity": "1",
+                "price": getattr(obj.LinkedObject, "Price", "N/A"),
+            }
+        )
 
     elif is_part_or_part_design(obj):
-        links_data.append({"parent": parent, "label": obj.Label, "part": obj.Label, "quantity": "1", "price":getattr(obj, "Price", "N/A")})
+        links_data.append(
+            {
+                "parent": parent,
+                "label": obj.Label,
+                "part": obj.Label,
+                "quantity": "1",
+                "price": getattr(obj, "Price", "N/A"),
+            }
+        )
 
 
 def group_profiles(profiles_data):

--- a/freecad/frameforge/create_bom_tool.py
+++ b/freecad/frameforge/create_bom_tool.py
@@ -4,17 +4,16 @@ from collections import defaultdict
 import FreeCAD as App
 import FreeCADGui as Gui
 
-from freecad.frameforge.best_fit import CutPart, Stock, best_fit_decreasing
 from freecad.frameforge._utils import (
     is_extrudedcutout,
     is_fusion,
     is_group,
+    is_link,
     is_part,
     is_profile,
     is_trimmedbody,
-    is_link
 )
-
+from freecad.frameforge.best_fit import CutPart, Stock, best_fit_decreasing
 from freecad.frameforge.create_bom import (
     group_links,
     group_profiles,

--- a/freecad/frameforge/create_custom_profiles_tool.py
+++ b/freecad/frameforge/create_custom_profiles_tool.py
@@ -134,15 +134,17 @@ class CreateCustomProfileTaskPanel:
             0.0,  # self.form.sb_radius2.value(),
             self.form.sb_length.value(),
             self.form.sb_weight.value(),
+            0.0,  # init_unit_price (no UI in custom profile dialog)
             False,  # self.form.cb_make_fillet.isChecked(),  # and self.form.family.currentText() not in ["Flat Sections", "Square", "Round Bar"],
-            False,  # self.form.cb_height_centered.isChecked(),
-            False,  # self.form.cb_width_centered.isChecked(),
+            1,  # self.form.cb_width_centered → center
+            1,  # self.form.cb_height_centered → center
             self.form.le_material.text(),  # self.form.combo_material.currentText(),
             "Custom Profile",  # self.form.combo_family.currentText(),
             "None",  # self.form.combo_size.currentText(),
             False,  # self.form.cb_combined_bevel.isChecked(),
             link_sub,
             self.custom_profile,
+            init_rotation=0.0,
         )
 
     def select_profile(self):

--- a/freecad/frameforge/create_edit_balloons_tool.py
+++ b/freecad/frameforge/create_edit_balloons_tool.py
@@ -5,20 +5,16 @@ import FreeCAD as App
 import FreeCADGui as Gui
 
 from freecad.frameforge._utils import (
+    get_profiles_and_links_from_object,
     is_extrudedcutout,
     is_fusion,
     is_group,
+    is_link,
     is_part,
     is_profile,
-    is_trimmedbody, 
-    is_link,
-    get_profiles_and_links_from_object
+    is_trimmedbody,
 )
-
-
 from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPATH, UIPATH, translate
-
-
 
 
 def place_balloon(balloon, move_balloon=False):
@@ -33,9 +29,9 @@ def place_balloon(balloon, move_balloon=False):
     C = view.getGeometricCenter()
 
     d = P.sub(C)
-    x2d = d.dot(X) # * view.Scale
-    y2d = d.dot(Y) # * view.Scale
-    
+    x2d = d.dot(X)  # * view.Scale
+    y2d = d.dot(Y)  # * view.Scale
+
     pageX = view.X.Value + x2d
     pageY = view.Y.Value + y2d
 
@@ -48,7 +44,7 @@ def place_balloon(balloon, move_balloon=False):
 
     balloon.Text = obj.PID
 
-	
+
 def create_balloon(view, src_obj):
     doc = App.ActiveDocument
     page = None
@@ -67,14 +63,12 @@ def create_balloon(view, src_obj):
     if page is None:
         raise RuntimeError("Impossible de trouver la page contenant la vue")
 
-    balloon = doc.addObject('TechDraw::DrawViewBalloon', f"Balloon_{src_obj.Label}")
+    balloon = doc.addObject("TechDraw::DrawViewBalloon", f"Balloon_{src_obj.Label}")
     balloon.addProperty("App::PropertyString", "TargetName", "FrameForge", "Target Profile").TargetName = src_obj.Name
     balloon.SourceView = view
     page.addView(balloon)
 
     place_balloon(balloon, move_balloon=True)
-
-
 
 
 class CreateBalloonsCommand:
@@ -101,16 +95,16 @@ class CreateBalloonsCommand:
                 return False
 
             objects = [
-                    sel
-                    for sel in selection if 
-                    is_fusion(sel)
-                    or is_part(sel)
-                    or is_group(sel)
-                    or is_profile(sel)
-                    or is_trimmedbody(sel)
-                    or is_extrudedcutout(sel)
-                    or is_link(sel)
-                ]
+                sel
+                for sel in selection
+                if is_fusion(sel)
+                or is_part(sel)
+                or is_group(sel)
+                or is_profile(sel)
+                or is_trimmedbody(sel)
+                or is_extrudedcutout(sel)
+                or is_link(sel)
+            ]
 
             if len(objects) <= 0:
                 return False
@@ -124,40 +118,35 @@ class CreateBalloonsCommand:
 
         views = [s for s in selection if s.TypeId == "TechDraw::DrawProjGroupItem"]
         objects = [
-                sel
-                for sel in selection if 
-                is_fusion(sel)
-                or is_part(sel)
-                or is_group(sel)
-                or is_profile(sel)
-                or is_trimmedbody(sel)
-                or is_extrudedcutout(sel)
-                or is_link(sel)
-            ]
+            sel
+            for sel in selection
+            if is_fusion(sel)
+            or is_part(sel)
+            or is_group(sel)
+            or is_profile(sel)
+            or is_trimmedbody(sel)
+            or is_extrudedcutout(sel)
+            or is_link(sel)
+        ]
 
         if len(objects) <= 0 or len(views) != 1:
             return
 
         view = views[0]
 
-
         App.ActiveDocument.openTransaction("Create Balloons")
 
         sel_profiles, sel_links = [], []
         for s in objects:
             get_profiles_and_links_from_object(sel_profiles, sel_links, s)
-        
 
         ff_objects = sel_profiles + sel_links
 
         for o in ff_objects:
             create_balloon(view, o)
 
-
         App.ActiveDocument.commitTransaction()
         # App.ActiveDocument.recompute()
-
-
 
 
 class ResfreshBalloonsCommand:
@@ -193,10 +182,8 @@ class ResfreshBalloonsCommand:
         for b in balloons:
             place_balloon(b)
 
-
         App.ActiveDocument.commitTransaction()
         # App.ActiveDocument.recompute()
-
 
 
 Gui.addCommand("FrameForge_CreateBalloons", CreateBalloonsCommand())

--- a/freecad/frameforge/create_profiles_tool.py
+++ b/freecad/frameforge/create_profiles_tool.py
@@ -38,6 +38,14 @@ class CreateProfileTaskPanel:
             if key in [k for t, k, v in param.GetContents()]:
                 func(param.GetBool(key))
 
+        # Center anchor radio buttons in grid cells (create_profiles2.ui)
+        form2 = self.form[1]
+        grid_anchor = form2.group_anchor.layout()
+        for ax in range(3):
+            for ay in range(3):
+                btn = getattr(form2, f"rb_anchor_{ax}_{ay}")
+                grid_anchor.setAlignment(btn, QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter)
+
         self.form_proxy.label_image.setPixmap(QtGui.QPixmap(os.path.join(PROFILEIMAGES_PATH, "Warehouse.png")))
 
         self.form_proxy.combo_material.currentIndexChanged.connect(self.on_material_changed)
@@ -47,6 +55,10 @@ class CreateProfileTaskPanel:
         self.form_proxy.cb_make_fillet.stateChanged.connect(self.on_cb_make_fillet_changed)
 
         self.form_proxy.combo_material.addItems([k for k in self.profiles])
+
+        for deg in ("0", "90", "180", "270"):
+            self.form_proxy.combo_rotation.addItem(deg)
+        self.form_proxy.combo_rotation.setCurrentIndex(0)
 
         param = App.ParamGet("User parameter:BaseApp/Preferences/Frameforge")
         if not param.IsEmpty():
@@ -70,9 +82,50 @@ class CreateProfileTaskPanel:
             execute_if_has_bool("Default Prefix Profile in Name", self.form_proxy.cb_prefix_profile_in_name.setChecked)
             execute_if_has_bool("Default Reverse Attachement", self.form_proxy.cb_reverse_attachment.setChecked)
             execute_if_has_bool("Default Make Fillet", self.form_proxy.cb_make_fillet.setChecked)
-            execute_if_has_bool("Default Height Centered", self.form_proxy.cb_height_centered.setChecked)
-            execute_if_has_bool("Default Width Centered", self.form_proxy.cb_width_centered.setChecked)
+            keys = [k for t, k, v in param.GetContents()]
+            if "Default AnchorX" in keys:
+                ax = max(0, min(2, param.GetInt("Default AnchorX", 1)))
+                ay = max(0, min(2, param.GetInt("Default AnchorY", 1)))
+                self.set_anchor(ax, ay)
+            elif "Default Width Centered" in keys or "Default Height Centered" in keys:
+                ax = 1 if param.GetBool("Default Width Centered", False) else 0
+                ay = 1 if param.GetBool("Default Height Centered", False) else 0
+                self.set_anchor(ax, ay)
+            if "Default RotationAngle" in keys:
+                try:
+                    val = float(param.GetString("Default RotationAngle", "0"))
+                    self.form_proxy.combo_rotation.setCurrentText(str(int(val) if val == int(val) else val))
+                except (TypeError, ValueError):
+                    self.form_proxy.combo_rotation.setCurrentText("0")
             execute_if_has_bool("Default Centered Bevel", self.form_proxy.cb_combined_bevel.setChecked)
+
+    def get_anchor(self):
+        """Return (anchor_x, anchor_y) 0=left/bottom, 1=center, 2=right/top."""
+        for ax in range(3):
+            for ay in range(3):
+                if getattr(self.form_proxy, f"rb_anchor_{ax}_{ay}").isChecked():
+                    return (ax, ay)
+        return (1, 1)
+
+    def set_anchor(self, anchor_x, anchor_y):
+        ax = max(0, min(2, anchor_x))
+        ay = max(0, min(2, anchor_y))
+        getattr(self.form_proxy, f"rb_anchor_{ax}_{ay}").setChecked(True)
+
+    def get_rotation(self):
+        """Return rotation angle in degrees (float)."""
+        try:
+            return float(self.form_proxy.combo_rotation.currentText())
+        except (TypeError, ValueError):
+            return 0.0
+
+    def set_rotation(self, degrees):
+        t = str(int(degrees) if degrees == int(degrees) else degrees)
+        i = self.form_proxy.combo_rotation.findText(t)
+        if i >= 0:
+            self.form_proxy.combo_rotation.setCurrentIndex(i)
+        else:
+            self.form_proxy.combo_rotation.setCurrentText(t)
 
     def on_material_changed(self, index):
         material = str(self.form_proxy.combo_material.currentText())
@@ -188,8 +241,10 @@ class CreateProfileTaskPanel:
             param.SetBool("Default Reverse Attachement", self.form_proxy.cb_reverse_attachment.isChecked())
 
             param.SetBool("Default Make Fillet", self.form_proxy.cb_make_fillet.isChecked())
-            param.SetBool("Default Height Centered", self.form_proxy.cb_height_centered.isChecked())
-            param.SetBool("Default Width Centered", self.form_proxy.cb_width_centered.isChecked())
+            ax, ay = self.get_anchor()
+            param.SetInt("Default AnchorX", ax)
+            param.SetInt("Default AnchorY", ay)
+            param.SetString("Default RotationAngle", self.form_proxy.combo_rotation.currentText())
             param.SetBool("Default Centered Bevel", self.form_proxy.cb_combined_bevel.isChecked())
 
             self.proceed()
@@ -302,13 +357,13 @@ class CreateProfileTaskPanel:
             self.form_proxy.sb_weight.value(),
             self.form_proxy.sb_unitprice.value(),
             self.form_proxy.cb_make_fillet.isChecked(),  # and self.form_proxy.family.currentText() not in ["Flat Sections", "Square", "Round Bar"],
-            self.form_proxy.cb_height_centered.isChecked(),
-            self.form_proxy.cb_width_centered.isChecked(),
+            *self.get_anchor(),
             self.form_proxy.combo_material.currentText(),
             self.form_proxy.combo_family.currentText(),
             self.form_proxy.combo_size.currentText(),
             self.form_proxy.cb_combined_bevel.isChecked(),
             link_sub,
+            init_rotation=self.get_rotation(),
         )
 
         # Create a ViewObject in current GUI

--- a/freecad/frameforge/create_profiles_tool.py
+++ b/freecad/frameforge/create_profiles_tool.py
@@ -363,6 +363,8 @@ class CreateProfileTaskPanel:
             self.form_proxy.combo_size.currentText(),
             self.form_proxy.cb_combined_bevel.isChecked(),
             link_sub,
+            init_mirror_h=self.form_proxy.cb_mirror_h.isChecked(),
+            init_mirror_v=self.form_proxy.cb_mirror_v.isChecked(),
             init_rotation=self.get_rotation(),
         )
 

--- a/freecad/frameforge/create_trimmed_profiles_tool.py
+++ b/freecad/frameforge/create_trimmed_profiles_tool.py
@@ -63,12 +63,11 @@ class CreateTrimmedProfileTaskPanel:
     def set_trimmed_body(self):
         if len(Gui.Selection.getSelectionEx()) == 1:
             trimmed_body = Gui.Selection.getSelectionEx()[0].Object
-            
+
             subels = Gui.Selection.getSelectionEx()[0].SubElementNames
             if len(subels) != 1 or not isinstance(trimmed_body.getSubObject(subels[0]), Part.Face):
                 App.Console.PrintMessage(translate("frameforge", f"Select a Face for TrimmedBody\n"))
                 return
-
 
             App.Console.PrintMessage(translate("frameforge", f"Set Trimmed body: {trimmed_body.Name}\n"))
             self.fp.TrimmedBody = trimmed_body
@@ -85,7 +84,9 @@ class CreateTrimmedProfileTaskPanel:
         trimming_boundaries = [e for e in self.fp.TrimmingBoundary]
 
         for selObject in Gui.Selection.getSelectionEx():
-            if len(selObject.SubElementNames) != 1 or not isinstance(selObject.Object.getSubObject(selObject.SubElementNames[0]), Part.Face):
+            if len(selObject.SubElementNames) != 1 or not isinstance(
+                selObject.Object.getSubObject(selObject.SubElementNames[0]), Part.Face
+            ):
                 App.Console.PrintMessage(translate("frameforge", f"Select a Faces only\n"))
                 return
 
@@ -195,7 +196,7 @@ class TrimProfileCommand:
                     o = sel.Object
                     if not hasattr(o, "Target") and not hasattr(o, "TrimmedBody"):
                         return False
-                    
+
                     if len(sel.SubElementNames) != 1:
                         return False
                     elif not isinstance(o.getSubObject(sel.SubElementNames[0]), Part.Face):

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -7,7 +7,7 @@ import FreeCADGui as Gui
 from PySide import QtCore, QtGui
 
 from freecad.frameforge.create_profiles_tool import CreateProfileTaskPanel
-from freecad.frameforge.profile import Profile, ViewProviderProfile
+from freecad.frameforge.profile import ANCHOR_X, ANCHOR_Y, Profile, ViewProviderProfile
 
 
 class EditProfileTaskPanel(CreateProfileTaskPanel):
@@ -36,8 +36,14 @@ class EditProfileTaskPanel(CreateProfileTaskPanel):
         except:
             App.Console.PrintMessage(f"Frameforge : can't find Unit Price for {self.profile.Label}\n")
         self.form_proxy.cb_make_fillet.setChecked(self.profile.MakeFillet)
-        self.form_proxy.cb_height_centered.setChecked(self.profile.CenteredOnHeight)
-        self.form_proxy.cb_width_centered.setChecked(self.profile.CenteredOnWidth)
+        if hasattr(self.profile, "AnchorX"):
+            ax = ANCHOR_X.index(self.profile.AnchorX) if self.profile.AnchorX in ANCHOR_X else 1
+            ay = ANCHOR_Y.index(self.profile.AnchorY) if self.profile.AnchorY in ANCHOR_Y else 1
+        else:
+            ax = 1 if getattr(self.profile, "CenteredOnWidth", False) else 0
+            ay = 1 if getattr(self.profile, "CenteredOnHeight", False) else 0
+        self.set_anchor(ax, ay)
+        self.set_rotation(getattr(self.profile, "RotationAngle", 0.0))
 
         self.form_proxy.combo_material.setCurrentText(self.profile.Material)
         self.form_proxy.combo_family.setCurrentText(self.profile.Family)
@@ -72,11 +78,11 @@ class EditProfileTaskPanel(CreateProfileTaskPanel):
             self.form_proxy.sb_weight.value(),
             self.form_proxy.sb_unitprice.value(),
             self.form_proxy.cb_make_fillet.isChecked(),  # and self.form_proxy.family.currentText() not in ["Flat Sections", "Square", "Round Bar"],
-            self.form_proxy.cb_height_centered.isChecked(),
-            self.form_proxy.cb_width_centered.isChecked(),
+            *self.get_anchor(),
             self.form_proxy.combo_material.currentText(),
             self.form_proxy.combo_family.currentText(),
             self.form_proxy.combo_size.currentText(),
+            init_rotation=self.get_rotation(),
         )
 
         App.ActiveDocument.commitTransaction()

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -44,6 +44,8 @@ class EditProfileTaskPanel(CreateProfileTaskPanel):
             ay = 1 if getattr(self.profile, "CenteredOnHeight", False) else 0
         self.set_anchor(ax, ay)
         self.set_rotation(getattr(self.profile, "RotationAngle", 0.0))
+        self.form_proxy.cb_mirror_h.setChecked(getattr(self.profile, "MirrorH", False))
+        self.form_proxy.cb_mirror_v.setChecked(getattr(self.profile, "MirrorV", False))
 
         self.form_proxy.combo_material.setCurrentText(self.profile.Material)
         self.form_proxy.combo_family.setCurrentText(self.profile.Family)
@@ -82,6 +84,8 @@ class EditProfileTaskPanel(CreateProfileTaskPanel):
             self.form_proxy.combo_material.currentText(),
             self.form_proxy.combo_family.currentText(),
             self.form_proxy.combo_size.currentText(),
+            init_mirror_h=self.form_proxy.cb_mirror_h.isChecked(),
+            init_mirror_v=self.form_proxy.cb_mirror_v.isChecked(),
             init_rotation=self.get_rotation(),
         )
 

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -30,7 +30,7 @@ class EditProfileTaskPanel(CreateProfileTaskPanel):
         self.form_proxy.sb_radius1.setValue(self.profile.RadiusLarge)
         self.form_proxy.sb_radius2.setValue(self.profile.RadiusSmall)
         self.form_proxy.sb_length.setValue(self.profile.ProfileLength)
-        self.form_proxy.sb_weight.setValue(self.profile.ApproxWeight )
+        self.form_proxy.sb_weight.setValue(self.profile.ApproxWeight)
         try:
             self.form_proxy.sb_unitprice.setValue(self.profile.UnitPrice)
         except:

--- a/freecad/frameforge/extruded_cutout.py
+++ b/freecad/frameforge/extruded_cutout.py
@@ -7,18 +7,18 @@ import FreeCADGui as Gui
 import Part
 from PySide import QtCore, QtGui
 
+from freecad.frameforge._utils import (
+    get_childrens_from_extrudedcutout,
+    get_profile_from_extrudedcutout,
+    get_readable_cutting_angles,
+    get_trimmed_profile_all_cutting_angles,
+    get_trimmedprofile_from_extrudedcutout,
+    length_along_normal,
+)
 from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPATH, UIPATH, translate
 from freecad.frameforge.frameforge_exceptions import FrameForgeException
-from freecad.frameforge._utils import (
-    get_readable_cutting_angles,
-    length_along_normal,
-    get_profile_from_extrudedcutout,
-    get_childrens_from_extrudedcutout,
-    get_trimmedprofile_from_extrudedcutout,
-    get_trimmed_profile_all_cutting_angles
-)
-
 from freecad.frameforge.version import __version__ as ff_version
+
 
 class ExtrudedCutout:
     def __init__(self, obj, sketch, selected_face):
@@ -40,7 +40,6 @@ class ExtrudedCutout:
             "Profile ID",
         ).PID = ""
         obj.setEditorMode("PID", 1)
-
 
         obj.addProperty("App::PropertyLinkSub", "baseObject", "ExtrudedCutout", "SelectedFace").baseObject = (
             selected_face
@@ -70,7 +69,6 @@ class ExtrudedCutout:
         ]
         obj.CutType = "Through All"
 
-
         # related to Profile
         obj.addProperty("App::PropertyString", "Family", "Profile", "")
         obj.setEditorMode("Family", 1)
@@ -90,7 +88,7 @@ class ExtrudedCutout:
         obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price")
         obj.setEditorMode("Price", 1)
 
-        #structure
+        # structure
         obj.addProperty("App::PropertyLength", "Width", "Structure", "Parameter for structure")
         obj.addProperty("App::PropertyLength", "Height", "Structure", "Parameter for structure")
         obj.addProperty("App::PropertyLength", "Length", "Structure", "Parameter for structure")
@@ -242,8 +240,7 @@ class ExtrudedCutout:
             obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price")
             obj.setEditorMode("Price", 1)
 
-
-            #structure
+            # structure
             obj.addProperty("App::PropertyLength", "Width", "Structure", "Parameter for structure")
             obj.addProperty("App::PropertyLength", "Height", "Structure", "Parameter for structure")
             obj.addProperty("App::PropertyLength", "Length", "Structure", "Parameter for structure")

--- a/freecad/frameforge/populate_ids.py
+++ b/freecad/frameforge/populate_ids.py
@@ -1,10 +1,8 @@
-
 import os
 from collections import defaultdict
 
 import FreeCAD as App
 import FreeCADGui as Gui
-
 
 from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPATH, UIPATH, translate
 
@@ -18,9 +16,9 @@ def letters_to_int(s: str) -> int:
     s = s.strip().upper()
     value = 0
     for c in s:
-        if not ('A' <= c <= 'Z'):
+        if not ("A" <= c <= "Z"):
             raise ValueError(f"Invalid letter ID: {s}")
-        value = value * 26 + (ord(c) - ord('A') + 1)
+        value = value * 26 + (ord(c) - ord("A") + 1)
     return value
 
 
@@ -37,12 +35,13 @@ def int_to_letters(n: int) -> str:
     while n > 0:
         n -= 1
         n, r = divmod(n, 26)
-        result.append(chr(ord('A') + r))
-    return ''.join(reversed(result))
+        result.append(chr(ord("A") + r))
+    return "".join(reversed(result))
 
 
 def number_str_to_int(s: str) -> int:
     return int(s)
+
 
 def int_to_number_str(n: int) -> str:
     if n <= 0:
@@ -50,12 +49,8 @@ def int_to_number_str(n: int) -> str:
     return str(n)
 
 
-
-
 class IdGenerator:
-    def __init__(self, used_ids: set[str], mode: str,
-                 strategy: str,
-                 start_value: str | None = None):
+    def __init__(self, used_ids: set[str], mode: str, strategy: str, start_value: str | None = None):
         """
         mode: "number" or "letter"
         strategy: "start_at", "continue", "fill_gaps"
@@ -116,15 +111,18 @@ class IdGenerator:
         return self.from_int(n)
 
 
-
-
-def populate_ids(sel_profiles, sel_links, doc_profiles, doc_links, 
-            numbering_type, 
-            allow_duplicated, 
-            reset_existing, 
-            numbering_scheme, 
-            start_number="1", start_letter="A"
-        ):
+def populate_ids(
+    sel_profiles,
+    sel_links,
+    doc_profiles,
+    doc_links,
+    numbering_type,
+    allow_duplicated,
+    reset_existing,
+    numbering_scheme,
+    start_number="1",
+    start_letter="A",
+):
 
     if reset_existing:
         for sp in sel_profiles:
@@ -141,9 +139,12 @@ def populate_ids(sel_profiles, sel_links, doc_profiles, doc_links,
             profiles_used = {o.PID for o in sel_profiles if o.PID}
             links_used = {o.PID for o in sel_links if o.PID}
         else:
-            profiles_used = {getattr(o, "PID", "") for o in doc_profiles if getattr(o, "PID", "")} - {getattr(o, "PID", "") for o in sel_profiles if getattr(o, "PID", "")}
-            links_used = {getattr(o, "PID", "") for o in doc_links if getattr(o, "PID", "")} - {getattr(o, "PID", "") for o in sel_links if getattr(o, "PID", "")}
-
+            profiles_used = {getattr(o, "PID", "") for o in doc_profiles if getattr(o, "PID", "")} - {
+                getattr(o, "PID", "") for o in sel_profiles if getattr(o, "PID", "")
+            }
+            links_used = {getattr(o, "PID", "") for o in doc_links if getattr(o, "PID", "")} - {
+                getattr(o, "PID", "") for o in sel_links if getattr(o, "PID", "")
+            }
 
     if numbering_scheme in ["fill_selection", "fill_document"]:
         strategy = "fill_gaps"
@@ -152,16 +153,18 @@ def populate_ids(sel_profiles, sel_links, doc_profiles, doc_links,
     elif numbering_scheme == "start_at":
         strategy = "start_at"
     else:
-        raise ValueError('Wrong numbering_scheme')
-
-
+        raise ValueError("Wrong numbering_scheme")
 
     if numbering_type == "all_numbers":
-        gen_profiles = IdGenerator(profiles_used | links_used, mode="number", strategy=strategy, start_value=start_number)
+        gen_profiles = IdGenerator(
+            profiles_used | links_used, mode="number", strategy=strategy, start_value=start_number
+        )
         gen_links = gen_profiles
 
     elif numbering_type == "all_letters":
-        gen_profiles = IdGenerator(profiles_used | links_used, mode="letter", strategy=strategy, start_value=start_letter)
+        gen_profiles = IdGenerator(
+            profiles_used | links_used, mode="letter", strategy=strategy, start_value=start_letter
+        )
         gen_links = gen_profiles
 
     elif numbering_type == "number_for_profiles_letters_for_links":
@@ -172,7 +175,7 @@ def populate_ids(sel_profiles, sel_links, doc_profiles, doc_links,
         gen_profiles = IdGenerator(profiles_used, mode="letter", strategy=strategy, start_value=start_letter)
         gen_links = IdGenerator(links_used, mode="number", strategy=strategy, start_value=start_number)
     else:
-        raise ValueError('Wrong numbering_type')
+        raise ValueError("Wrong numbering_type")
 
     for sp in sel_profiles:
         sp.PID = gen_profiles.next()

--- a/freecad/frameforge/resources/ui/create_profiles2.ui
+++ b/freecad/frameforge/resources/ui/create_profiles2.ui
@@ -188,23 +188,66 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="cb_width_centered">
-          <property name="text">
-           <string>Width Centered</string>
+         <widget class="QGroupBox" name="group_anchor">
+          <property name="title">
+           <string>Path alignment</string>
           </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
+          <layout class="QGridLayout" name="grid_anchor">
+           <item row="0" column="0">
+            <widget class="QRadioButton" name="rb_anchor_0_2"/>
+           </item>
+           <item row="0" column="1">
+            <widget class="QRadioButton" name="rb_anchor_1_2"/>
+           </item>
+           <item row="0" column="2">
+            <widget class="QRadioButton" name="rb_anchor_2_2"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QRadioButton" name="rb_anchor_0_1"/>
+           </item>
+           <item row="1" column="1">
+            <widget class="QRadioButton" name="rb_anchor_1_1">
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QRadioButton" name="rb_anchor_2_1"/>
+           </item>
+           <item row="2" column="0">
+            <widget class="QRadioButton" name="rb_anchor_0_0"/>
+           </item>
+           <item row="2" column="1">
+            <widget class="QRadioButton" name="rb_anchor_1_0"/>
+           </item>
+           <item row="2" column="2">
+            <widget class="QRadioButton" name="rb_anchor_2_0"/>
+           </item>
+          </layout>
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="cb_height_centered">
-          <property name="text">
-           <string>Height Centered</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
+         <widget class="QWidget" name="widget_rotation" native="true">
+          <layout class="QFormLayout" name="form_rotation">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_rotation">
+             <property name="text">
+              <string>Rotation (°)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="combo_rotation">
+             <property name="editable">
+              <bool>true</bool>
+             </property>
+             <property name="currentText">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
         <item>

--- a/freecad/frameforge/resources/ui/create_profiles2.ui
+++ b/freecad/frameforge/resources/ui/create_profiles2.ui
@@ -228,6 +228,20 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="cb_mirror_h">
+          <property name="text">
+           <string>Mirror horizontally</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cb_mirror_v">
+          <property name="text">
+           <string>Mirror vertically</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QWidget" name="widget_rotation" native="true">
           <layout class="QFormLayout" name="form_rotation">
            <item row="0" column="0">

--- a/freecad/frameforge/trimmed_profile.py
+++ b/freecad/frameforge/trimmed_profile.py
@@ -9,16 +9,16 @@ import FreeCADGui as Gui
 import Part
 from PySide import QtCore, QtGui
 
-from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPATH, UIPATH, translate
 from freecad.frameforge._utils import (
-    get_readable_cutting_angles,
-    length_along_normal,
-    get_profile_from_trimmedbody,
     get_childrens_from_trimmedbody,
-    get_trimmed_profile_all_cutting_angles
+    get_profile_from_trimmedbody,
+    get_readable_cutting_angles,
+    get_trimmed_profile_all_cutting_angles,
+    length_along_normal,
 )
-
+from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPATH, UIPATH, translate
 from freecad.frameforge.version import __version__ as ff_version
+
 
 class TrimmedProfile:
     def __init__(self, obj):
@@ -36,7 +36,6 @@ class TrimmedProfile:
             "Profile ID",
         ).PID = ""
         obj.setEditorMode("PID", 1)
-
 
         obj.addProperty(
             "App::PropertyLink", "TrimmedBody", "TrimmedProfile", translate("App::Property", "Body to be trimmed")
@@ -80,8 +79,7 @@ class TrimmedProfile:
         obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price")
         obj.setEditorMode("Price", 1)
 
-
-        #structure
+        # structure
         obj.addProperty("App::PropertyLength", "Width", "Structure", "Parameter for structure")
         obj.addProperty("App::PropertyLength", "Height", "Structure", "Parameter for structure")
         obj.addProperty("App::PropertyLength", "Length", "Structure", "Parameter for structure")
@@ -230,7 +228,6 @@ class TrimmedProfile:
 
         obj.CuttingAngleA = cut_angles[0]
         obj.CuttingAngleB = cut_angles[1]
-            
 
     def run_compatibility_migrations(self, obj):
         if not hasattr(obj, "FrameforgeVersion"):
@@ -238,7 +235,6 @@ class TrimmedProfile:
             for link in obj.TrimmingBoundary:
                 link[0].Proxy.execute(link[0])
             obj.TrimmedBody.Proxy.execute(obj.TrimmedBody)
-
 
             App.Console.PrintMessage(f"Frameforge::object migration : Migrate {obj.Label} to 0.1.8\n")
 
@@ -269,8 +265,7 @@ class TrimmedProfile:
             obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price")
             obj.setEditorMode("Price", 1)
 
-
-            #structure
+            # structure
             obj.addProperty("App::PropertyLength", "Width", "Structure", "Parameter for structure")
             obj.addProperty("App::PropertyLength", "Height", "Structure", "Parameter for structure")
             obj.addProperty("App::PropertyLength", "Length", "Structure", "Parameter for structure")


### PR DESCRIPTION
Path alignment: Replaces the two “centered on width/height” checkboxes with a 3×3 grid: horizontal Left / Center / Right, vertical Bottom / Center / Top. In the object’s properties, AnchorX and AnchorY are dropdowns (PropertyEnumeration). In the dialog, the top row is Top, the bottom row is Bottom; radio buttons are centered in their cells.

Section rotation: Adds a RotationAngle property (degrees around the path axis) and a “Rotation (°)” field in the create/edit profile dialog (0, 90, 180, 270), with a default stored in preferences.

Compatibility: Old documents using CenteredOnWidth/CenteredOnHeight are migrated on load to AnchorX/AnchorY with equivalent values (centered → Center, otherwise Left/Bottom).