### PR TITLE
Proper place of cutplane on miter ends

### DIFF
--- a/freecad/frameforge/trimmed_profile.py
+++ b/freecad/frameforge/trimmed_profile.py
@@ -151,13 +151,18 @@ class TrimmedProfile:
             precision = 0.001
             target1 = self.getTarget(fp.TrimmedBody)
             edge1 = doc.getObject(target1[0].Name).getSubObject(target1[1][0])
+            shape1 = fp.TrimmedBody.Shape.SubShapes[0]
+            bound_shapes = []
             bounds_target = []
             for bound in fp.TrimmingBoundary:
+                bound_shapes.append(bound[0].Shape.SubShapes[0])
                 bounds_target.append(self.getTarget(bound[0]))
             trimming_boundary_edges = []
             for target in bounds_target:
                 trimming_boundary_edges.append(doc.getObject(target[0].Name).getSubObject(target[1][0]))
-            for edge2 in trimming_boundary_edges:
+            for i in range(0, len(trimming_boundary_edges)):
+                edge2 = trimming_boundary_edges[i]
+                shape2 = bound_shapes[i]
                 end1 = edge1.Vertexes[-1].Point
                 start1 = edge1.Vertexes[0].Point
                 end2 = edge2.Vertexes[-1].Point
@@ -190,8 +195,9 @@ class TrimmedProfile:
                     p3 = start2
 
                 normal = Part.Plane(p1, p2, p3).toShape().normalAt(0, 0)
-                cutplane = Part.makePlane(10, 10, p1, vec1, normal)
-                cutplane.rotate(p1, normal, -90 + bisect)
+                intersection = shape1.common(shape2)
+                cutplane = Part.makePlane(10, 10, intersection.CenterOfGravity, vec1, normal)
+                cutplane.rotate(intersection.CenterOfGravity, normal, -90 + bisect)
                 cut_shapes.append(self.getOutsideCV(cutplane, fp.TrimmedBody.Shape))
 
         if len(cut_shapes) > 0:

--- a/freecad/frameforge/trimmed_profile.py
+++ b/freecad/frameforge/trimmed_profile.py
@@ -196,8 +196,8 @@ class TrimmedProfile:
 
                 normal = Part.Plane(p1, p2, p3).toShape().normalAt(0, 0)
                 intersection = shape1.common(shape2)
-                cutplane = Part.makePlane(10, 10, intersection.CenterOfGravity, vec1, normal)
-                cutplane.rotate(intersection.CenterOfGravity, normal, -90 + bisect)
+                cutplane = Part.makePlane(10, 10, intersection.BoundBox.Center, vec1, normal)
+                cutplane.rotate(intersection.BoundBox.Center, normal, -90 + bisect)
                 cut_shapes.append(self.getOutsideCV(cutplane, fp.TrimmedBody.Shape))
 
         if len(cut_shapes) > 0:

--- a/freecad/frameforge/trimmed_profile.py
+++ b/freecad/frameforge/trimmed_profile.py
@@ -196,6 +196,8 @@ class TrimmedProfile:
 
                 normal = Part.Plane(p1, p2, p3).toShape().normalAt(0, 0)
                 intersection = shape1.common(shape2)
+                if not intersection.Length:
+                    raise RuntimeError("End Miter: profiles don't intersect. You can add offsets.")
                 cutplane = Part.makePlane(10, 10, intersection.BoundBox.Center, vec1, normal)
                 cutplane.rotate(intersection.BoundBox.Center, normal, -90 + bisect)
                 cut_shapes.append(self.getOutsideCV(cutplane, fp.TrimmedBody.Shape))


### PR DESCRIPTION
When profiles have different placement along edges, cutplane should be moved to the center of intersection.

Before:
<img width="1061" height="267" alt="изображение" src="https://github.com/user-attachments/assets/c5156ea0-2432-4393-aad5-be3f4b0e1218" />

After:
<img width="1280" height="353" alt="изображение" src="https://github.com/user-attachments/assets/e303bca0-bdb6-4a4f-8bd5-153d202fc51c" />
