### PR TITLE
Fix syntax error on py311

### DIFF
--- a/freecad/frameforge/utilities.py
+++ b/freecad/frameforge/utilities.py
@@ -41,9 +41,8 @@ class ExportTechDrawCommand:
 
         for obj in doc.Objects:
             if obj.TypeId == "TechDraw::DrawPage":
-                pdf_path = os.path.join(
-                    out_dir, f"{"".join(c for c in obj.Label if c.isalnum() or c in (' ', '.', '_')).rstrip()}.pdf"
-                )
+                pdf_name = "".join(c for c in obj.Label if c.isalnum() or c in (" ", ".", "_")).rstrip()
+                pdf_path = os.path.join(out_dir, f"{pdf_name}.pdf")
 
                 TechDrawGui.exportPageAsPdf(obj, pdf_path)
 


### PR DESCRIPTION
FreeCAD_weekly-2026.02.18-Linux-x86_64-py311.AppImage

11:29:24  f-string: expecting '}' (utilities.py, line 46)