### PR TITLE
fix(ui): stabilize profile edit state

### DIFF
--- a/freecad/frameforge/create_profiles_tool.py
+++ b/freecad/frameforge/create_profiles_tool.py
@@ -69,13 +69,19 @@ class BaseProfileTaskPanel(ABC):
             return
         self.proceed()
 
-    def resolve_material_for_family(self, material, family):
+    def resolve_material_for_family(self, material, family, size_name=""):
         if material in self.profiles:
             return material
+        matches = []
         for candidate, families in self.profiles.items():
-            if family in families:
-                return candidate
-        return material
+            if family not in families:
+                continue
+            if size_name and size_name not in families[family]["sizes"]:
+                continue
+            matches.append(candidate)
+        if len(matches) == 1:
+            return matches[0]
+        return None
 
     def populate_family_combo(self, material):
         self.form_proxy.combo_family.clear()

--- a/freecad/frameforge/create_profiles_tool.py
+++ b/freecad/frameforge/create_profiles_tool.py
@@ -15,6 +15,7 @@ from freecad.frameforge.profile import Profile, ViewProviderProfile
 class BaseProfileTaskPanel(ABC):
     def __init__(self):
         self._objects = {}
+        self._suspend_proceed = False
 
         self.form = [
             Gui.PySideUic.loadUi(os.path.join(UIPATH, "create_profiles1.ui")),
@@ -56,6 +57,11 @@ class BaseProfileTaskPanel(ABC):
         for ax in range(3):
             for ay in range(3):
                 getattr(self.form_proxy, f"rb_anchor_{ax}_{ay}").blockSignals(not enable)
+
+    def request_proceed(self):
+        if self._suspend_proceed:
+            return
+        self.proceed()
 
     def initialize_ui(self):
         def execute_if_has_bool(key, func):
@@ -126,26 +132,26 @@ class BaseProfileTaskPanel(ABC):
 
         self.form_proxy.cb_make_fillet.stateChanged.connect(self.on_cb_make_fillet_changed)
 
-        self.form_proxy.cb_mirror_h.stateChanged.connect(self.proceed)
-        self.form_proxy.cb_mirror_v.stateChanged.connect(self.proceed)
-        self.form_proxy.cb_pre_extend.stateChanged.connect(self.proceed)
-        self.form_proxy.combo_rotation.currentIndexChanged.connect(self.proceed)
+        self.form_proxy.cb_mirror_h.stateChanged.connect(self.request_proceed)
+        self.form_proxy.cb_mirror_v.stateChanged.connect(self.request_proceed)
+        self.form_proxy.cb_pre_extend.stateChanged.connect(self.request_proceed)
+        self.form_proxy.combo_rotation.currentIndexChanged.connect(self.request_proceed)
         for ax in range(3):
             for ay in range(3):
-                getattr(self.form_proxy, f"rb_anchor_{ax}_{ay}").clicked.connect(self.proceed)
+                getattr(self.form_proxy, f"rb_anchor_{ax}_{ay}").clicked.connect(self.request_proceed)
 
-        self.form_proxy.sb_width.valueChanged.connect(self.proceed)
-        self.form_proxy.sb_height.valueChanged.connect(self.proceed)
-        self.form_proxy.sb_main_thickness.valueChanged.connect(self.proceed)
-        self.form_proxy.sb_flange_thickness.valueChanged.connect(self.proceed)
-        self.form_proxy.sb_radius1.valueChanged.connect(self.proceed)
-        self.form_proxy.sb_radius2.valueChanged.connect(self.proceed)
-        self.form_proxy.sb_length.valueChanged.connect(self.proceed)
+        self.form_proxy.sb_width.valueChanged.connect(self.request_proceed)
+        self.form_proxy.sb_height.valueChanged.connect(self.request_proceed)
+        self.form_proxy.sb_main_thickness.valueChanged.connect(self.request_proceed)
+        self.form_proxy.sb_flange_thickness.valueChanged.connect(self.request_proceed)
+        self.form_proxy.sb_radius1.valueChanged.connect(self.request_proceed)
+        self.form_proxy.sb_radius2.valueChanged.connect(self.request_proceed)
+        self.form_proxy.sb_length.valueChanged.connect(self.request_proceed)
 
-        self.form_proxy.cb_sketch_in_name.stateChanged.connect(self.proceed)
-        self.form_proxy.cb_family_in_name.stateChanged.connect(self.proceed)
-        self.form_proxy.cb_size_in_name.stateChanged.connect(self.proceed)
-        self.form_proxy.cb_prefix_profile_in_name.stateChanged.connect(self.proceed)
+        self.form_proxy.cb_sketch_in_name.stateChanged.connect(self.request_proceed)
+        self.form_proxy.cb_family_in_name.stateChanged.connect(self.request_proceed)
+        self.form_proxy.cb_size_in_name.stateChanged.connect(self.request_proceed)
+        self.form_proxy.cb_prefix_profile_in_name.stateChanged.connect(self.request_proceed)
 
     def get_anchor(self):
         """Return (anchor_x, anchor_y) 0=left/bottom, 1=center, 2=right/top."""
@@ -254,11 +260,11 @@ class BaseProfileTaskPanel(ABC):
                 sb.setValue(float(profile[s]))
 
             self.enable_signals(True)
-            self.proceed()
+            self.request_proceed()
 
     def on_cb_make_fillet_changed(self, state):
         self.update_image()
-        self.proceed()
+        self.request_proceed()
 
     def update_image(self):
         material = str(self.form_proxy.combo_material.currentText())

--- a/freecad/frameforge/create_profiles_tool.py
+++ b/freecad/frameforge/create_profiles_tool.py
@@ -130,18 +130,24 @@ class BaseProfileTaskPanel(ABC):
                 if default_material_index > -1:
                     self.form_proxy.combo_material.setCurrentIndex(default_material_index)
 
-                    default_family_index = self.form_proxy.combo_family.findText(param.GetString("Default Profile Family"))
+                    default_family_index = self.form_proxy.combo_family.findText(
+                        param.GetString("Default Profile Family")
+                    )
                     if default_family_index > -1:
                         self.form_proxy.combo_family.setCurrentIndex(default_family_index)
 
-                        default_size_index = self.form_proxy.combo_size.findText(param.GetString("Default Profile Size"))
+                        default_size_index = self.form_proxy.combo_size.findText(
+                            param.GetString("Default Profile Size")
+                        )
                         if default_size_index > -1:
                             self.form_proxy.combo_size.setCurrentIndex(default_size_index)
 
                 execute_if_has_bool("Default Sketch in Name", self.form_proxy.cb_sketch_in_name.setChecked)
                 execute_if_has_bool("Default Family in Name", self.form_proxy.cb_family_in_name.setChecked)
                 execute_if_has_bool("Default Size in Name", self.form_proxy.cb_size_in_name.setChecked)
-                execute_if_has_bool("Default Prefix Profile in Name", self.form_proxy.cb_prefix_profile_in_name.setChecked)
+                execute_if_has_bool(
+                    "Default Prefix Profile in Name", self.form_proxy.cb_prefix_profile_in_name.setChecked
+                )
                 execute_if_has_bool("Default Make Fillet", self.form_proxy.cb_make_fillet.setChecked)
                 execute_if_has_bool("Default Mirror Horizontally", self.form_proxy.cb_mirror_h.setChecked)
                 execute_if_has_bool("Default Mirror Vertically", self.form_proxy.cb_mirror_v.setChecked)

--- a/freecad/frameforge/create_profiles_tool.py
+++ b/freecad/frameforge/create_profiles_tool.py
@@ -51,9 +51,15 @@ class BaseProfileTaskPanel(ABC):
         self.form_proxy.sb_radius1.blockSignals(not enable)
         self.form_proxy.sb_radius2.blockSignals(not enable)
         self.form_proxy.sb_length.blockSignals(not enable)
+        self.form_proxy.cb_make_fillet.blockSignals(not enable)
         self.form_proxy.cb_mirror_h.blockSignals(not enable)
         self.form_proxy.cb_mirror_v.blockSignals(not enable)
+        self.form_proxy.cb_pre_extend.blockSignals(not enable)
         self.form_proxy.combo_rotation.blockSignals(not enable)
+        self.form_proxy.cb_sketch_in_name.blockSignals(not enable)
+        self.form_proxy.cb_family_in_name.blockSignals(not enable)
+        self.form_proxy.cb_size_in_name.blockSignals(not enable)
+        self.form_proxy.cb_prefix_profile_in_name.blockSignals(not enable)
         for ax in range(3):
             for ay in range(3):
                 getattr(self.form_proxy, f"rb_anchor_{ax}_{ay}").blockSignals(not enable)
@@ -63,10 +69,36 @@ class BaseProfileTaskPanel(ABC):
             return
         self.proceed()
 
-    def initialize_ui(self):
+    def resolve_material_for_family(self, material, family):
+        if material in self.profiles:
+            return material
+        for candidate, families in self.profiles.items():
+            if family in families:
+                return candidate
+        return material
+
+    def populate_family_combo(self, material):
+        self.form_proxy.combo_family.clear()
+        self.form_proxy.combo_size.clear()
+        if material not in self.profiles:
+            return
+        self.form_proxy.combo_family.addItems([f for f in self.profiles[material]])
+
+    def populate_size_combo(self, material, family):
+        self.form_proxy.combo_size.clear()
+        if material not in self.profiles:
+            return
+        if family not in self.profiles[material]:
+            return
+        self.form_proxy.combo_size.addItems([s for s in self.profiles[material][family]["sizes"]])
+
+    def initialize_ui(self, apply_defaults=True):
         def execute_if_has_bool(key, func):
             if key in [k for t, k, v in param.GetContents()]:
                 func(param.GetBool(key))
+
+        previous_suspend = self._suspend_proceed
+        self._suspend_proceed = True
 
         # Center anchor radio buttons in grid cells (create_profiles2.ui)
         form2 = self.form[1]
@@ -78,57 +110,60 @@ class BaseProfileTaskPanel(ABC):
 
         self.form_proxy.label_image.setPixmap(QtGui.QPixmap(os.path.join(PROFILEIMAGES_PATH, "Warehouse.png")))
 
-        # sig/slot
-        self.form_proxy.combo_material.currentIndexChanged.connect(self.on_material_changed)
-        self.form_proxy.combo_family.currentIndexChanged.connect(self.on_family_changed)
-        self.form_proxy.combo_size.currentIndexChanged.connect(self.on_size_changed)
-
         self.form_proxy.combo_material.addItems([k for k in self.profiles])
 
         for deg in ("0", "90", "180", "270"):
             self.form_proxy.combo_rotation.addItem(deg)
         self.form_proxy.combo_rotation.setCurrentIndex(0)
 
-        param = App.ParamGet("User parameter:BaseApp/Preferences/Frameforge")
-        if not param.IsEmpty():
-            default_material_index = self.form_proxy.combo_material.findText(
-                param.GetString("Default Profile Material")
-            )
-            if default_material_index > -1:
-                self.form_proxy.combo_material.setCurrentIndex(default_material_index)
+        self.form_proxy.combo_material.currentIndexChanged.connect(self.on_material_changed)
+        self.form_proxy.combo_family.currentIndexChanged.connect(self.on_family_changed)
+        self.form_proxy.combo_size.currentIndexChanged.connect(self.on_size_changed)
+        self.on_material_changed(None)
 
-                default_family_index = self.form_proxy.combo_family.findText(param.GetString("Default Profile Family"))
-                if default_family_index > -1:
-                    self.form_proxy.combo_family.setCurrentIndex(default_family_index)
+        if apply_defaults:
+            param = App.ParamGet("User parameter:BaseApp/Preferences/Frameforge")
+            if not param.IsEmpty():
+                default_material_index = self.form_proxy.combo_material.findText(
+                    param.GetString("Default Profile Material")
+                )
+                if default_material_index > -1:
+                    self.form_proxy.combo_material.setCurrentIndex(default_material_index)
 
-                    default_size_index = self.form_proxy.combo_size.findText(param.GetString("Default Profile Size"))
-                    if default_size_index > -1:
-                        self.form_proxy.combo_size.setCurrentIndex(default_size_index)
+                    default_family_index = self.form_proxy.combo_family.findText(param.GetString("Default Profile Family"))
+                    if default_family_index > -1:
+                        self.form_proxy.combo_family.setCurrentIndex(default_family_index)
 
-            execute_if_has_bool("Default Sketch in Name", self.form_proxy.cb_sketch_in_name.setChecked)
-            execute_if_has_bool("Default Family in Name", self.form_proxy.cb_family_in_name.setChecked)
-            execute_if_has_bool("Default Size in Name", self.form_proxy.cb_size_in_name.setChecked)
-            execute_if_has_bool("Default Prefix Profile in Name", self.form_proxy.cb_prefix_profile_in_name.setChecked)
-            execute_if_has_bool("Default Make Fillet", self.form_proxy.cb_make_fillet.setChecked)
-            execute_if_has_bool("Default Mirror Horizontally", self.form_proxy.cb_mirror_h.setChecked)
-            execute_if_has_bool("Default Mirror Vertically", self.form_proxy.cb_mirror_v.setChecked)
-            execute_if_has_bool("Default Pre Extend", self.form_proxy.cb_pre_extend.setChecked)
-            keys = [k for t, k, v in param.GetContents()]
-            if "Default AnchorX" in keys:
-                ax = max(0, min(2, param.GetInt("Default AnchorX", 1)))
-                ay = max(0, min(2, param.GetInt("Default AnchorY", 1)))
-                self.set_anchor(ax, ay)
-            elif "Default Width Centered" in keys or "Default Height Centered" in keys:
-                ax = 1 if param.GetBool("Default Width Centered", False) else 0
-                ay = 1 if param.GetBool("Default Height Centered", False) else 0
-                self.set_anchor(ax, ay)
-            if "Default RotationAngle" in keys:
-                try:
-                    val = float(param.GetString("Default RotationAngle", "0"))
-                    self.form_proxy.combo_rotation.setCurrentText(str(int(val) if val == int(val) else val))
-                except (TypeError, ValueError):
-                    self.form_proxy.combo_rotation.setCurrentText("0")
-            execute_if_has_bool("Default Centered Bevel", self.form_proxy.cb_combined_bevel.setChecked)
+                        default_size_index = self.form_proxy.combo_size.findText(param.GetString("Default Profile Size"))
+                        if default_size_index > -1:
+                            self.form_proxy.combo_size.setCurrentIndex(default_size_index)
+
+                execute_if_has_bool("Default Sketch in Name", self.form_proxy.cb_sketch_in_name.setChecked)
+                execute_if_has_bool("Default Family in Name", self.form_proxy.cb_family_in_name.setChecked)
+                execute_if_has_bool("Default Size in Name", self.form_proxy.cb_size_in_name.setChecked)
+                execute_if_has_bool("Default Prefix Profile in Name", self.form_proxy.cb_prefix_profile_in_name.setChecked)
+                execute_if_has_bool("Default Make Fillet", self.form_proxy.cb_make_fillet.setChecked)
+                execute_if_has_bool("Default Mirror Horizontally", self.form_proxy.cb_mirror_h.setChecked)
+                execute_if_has_bool("Default Mirror Vertically", self.form_proxy.cb_mirror_v.setChecked)
+                execute_if_has_bool("Default Pre Extend", self.form_proxy.cb_pre_extend.setChecked)
+                keys = [k for t, k, v in param.GetContents()]
+                if "Default AnchorX" in keys:
+                    ax = max(0, min(2, param.GetInt("Default AnchorX", 1)))
+                    ay = max(0, min(2, param.GetInt("Default AnchorY", 1)))
+                    self.set_anchor(ax, ay)
+                elif "Default Width Centered" in keys or "Default Height Centered" in keys:
+                    ax = 1 if param.GetBool("Default Width Centered", False) else 0
+                    ay = 1 if param.GetBool("Default Height Centered", False) else 0
+                    self.set_anchor(ax, ay)
+                if "Default RotationAngle" in keys:
+                    try:
+                        val = float(param.GetString("Default RotationAngle", "0"))
+                        self.form_proxy.combo_rotation.setCurrentText(str(int(val) if val == int(val) else val))
+                    except (TypeError, ValueError):
+                        self.form_proxy.combo_rotation.setCurrentText("0")
+                execute_if_has_bool("Default Centered Bevel", self.form_proxy.cb_combined_bevel.setChecked)
+
+        self._suspend_proceed = previous_suspend
 
         self.form_proxy.cb_make_fillet.stateChanged.connect(self.on_cb_make_fillet_changed)
 
@@ -183,21 +218,37 @@ class BaseProfileTaskPanel(ABC):
 
     def on_material_changed(self, index):
         material = str(self.form_proxy.combo_material.currentText())
+        previous_suspend = self._suspend_proceed
+        self._suspend_proceed = True
 
         self.enable_signals(False)
-
-        self.form_proxy.combo_family.clear()
-        self.form_proxy.combo_family.addItems([f for f in self.profiles[material]])
-
+        self.populate_family_combo(material)
+        has_family = self.form_proxy.combo_family.count() > 0
+        if has_family:
+            self.form_proxy.combo_family.setCurrentIndex(0)
         self.enable_signals(True)
+        self._suspend_proceed = previous_suspend
 
-        self.form_proxy.combo_family.setCurrentIndex(0)
+        if not has_family:
+            return
         self.on_family_changed(None)
 
     def on_family_changed(self, index):
         material = str(self.form_proxy.combo_material.currentText())
         family = str(self.form_proxy.combo_family.currentText())
+        previous_suspend = self._suspend_proceed
+        self._suspend_proceed = True
 
+        if material not in self.profiles:
+            self.form_proxy.combo_size.clear()
+            self._suspend_proceed = previous_suspend
+            return
+        if family not in self.profiles[material]:
+            self.form_proxy.combo_size.clear()
+            self._suspend_proceed = previous_suspend
+            return
+
+        self.enable_signals(False)
         self.form_proxy.cb_make_fillet.setChecked(self.profiles[material][family]["fillet"])
         self.form_proxy.cb_make_fillet.setEnabled(self.profiles[material][family]["fillet"])
 
@@ -206,16 +257,28 @@ class BaseProfileTaskPanel(ABC):
         self.form_proxy.label_norm.setText(self.profiles[material][family]["norm"])
         self.form_proxy.label_unit.setText(self.profiles[material][family]["unit"])
 
-        self.form_proxy.combo_size.clear()
-        self.form_proxy.combo_size.addItems([s for s in self.profiles[material][family]["sizes"]])
+        self.populate_size_combo(material, family)
+        has_size = self.form_proxy.combo_size.count() > 0
+        if has_size:
+            self.form_proxy.combo_size.setCurrentIndex(0)
+        self.enable_signals(True)
+        self._suspend_proceed = previous_suspend
 
-        self.form_proxy.combo_size.setCurrentIndex(0)
+        if not has_size:
+            return
         self.on_size_changed(None)
 
     def on_size_changed(self, index):
         material = str(self.form_proxy.combo_material.currentText())
         family = str(self.form_proxy.combo_family.currentText())
         size = str(self.form_proxy.combo_size.currentText())
+
+        if material not in self.profiles:
+            return
+        if family not in self.profiles[material]:
+            return
+        if size not in self.profiles[material][family]["sizes"]:
+            return
 
         if size != "":
             profile = self.profiles[material][family]["sizes"][size]
@@ -278,6 +341,7 @@ class BaseProfileTaskPanel(ABC):
         self.form_proxy.label_image.setPixmap(QtGui.QPixmap(os.path.join(PROFILEIMAGES_PATH, material, img_name)))
 
     def update_profile(self, profile):
+        offset = self.get_pre_extend_offset()
         profile.Proxy.set_properties(
             profile,
             self.form_proxy.sb_width.value(),
@@ -297,7 +361,14 @@ class BaseProfileTaskPanel(ABC):
             init_mirror_h=self.form_proxy.cb_mirror_h.isChecked(),
             init_mirror_v=self.form_proxy.cb_mirror_v.isChecked(),
             init_rotation=self.get_rotation(),
+            init_offset_a=offset,
+            init_offset_b=offset,
         )
+
+    def get_pre_extend_offset(self):
+        if not self.form_proxy.cb_pre_extend.isChecked():
+            return 0.0
+        return max(self.form_proxy.sb_width.value(), self.form_proxy.sb_height.value())
 
     @abstractmethod
     def proceed(self):

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -1,13 +1,8 @@
-import glob
-import json
-import os
-
 import FreeCAD as App
 import FreeCADGui as Gui
-from PySide import QtCore, QtGui
 
 from freecad.frameforge.create_profiles_tool import BaseProfileTaskPanel
-from freecad.frameforge.profile import ANCHOR_X, ANCHOR_Y, Profile, ViewProviderProfile
+from freecad.frameforge.profile import ANCHOR_X, ANCHOR_Y
 
 
 class EditProfileTaskPanel(BaseProfileTaskPanel):
@@ -37,7 +32,7 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         self.form_proxy.sb_weight.setValue(self.profile.ApproxWeight)
         try:
             self.form_proxy.sb_unitprice.setValue(self.profile.UnitPrice)
-        except:
+        except AttributeError:
             App.Console.PrintMessage(f"Frameforge : can't find Unit Price for {self.profile.Label}\n")
         self.form_proxy.cb_make_fillet.setChecked(self.profile.MakeFillet)
         self.form_proxy.cb_pre_extend.setChecked(self._profile_has_pre_extend())

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -58,14 +58,17 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         self._suspend_proceed = False
 
     def _set_profile_combo_state(self):
-        material = self.resolve_material_for_family(self.profile.Material, self.profile.Family)
+        material = self.resolve_material_for_family(self.profile.Material, self.profile.Family, self.profile.SizeName)
         family = self.profile.Family
         size_name = self.profile.SizeName
+
+        if material is None:
+            material = str(self.form_proxy.combo_material.currentText())
 
         material_index = self.form_proxy.combo_material.findText(material)
         if material_index >= 0:
             self.form_proxy.combo_material.setCurrentIndex(material_index)
-        else:
+        elif material:
             self.form_proxy.combo_material.setCurrentText(material)
 
         self.populate_family_combo(material)
@@ -94,8 +97,6 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         App.ActiveDocument.openTransaction("Edit Profile")
 
         self.initialize_ui()
-
-        self.proceed()
 
         self.profile.ViewObject.Transparency = 50
         self.profile.ViewObject.ShapeColor = (0.8, 0.2, 0.1)

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -18,6 +18,7 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         super().__init__()
 
     def initialize_ui(self):
+        self._suspend_proceed = True
         super().initialize_ui()
 
         self.form_proxy.groupBox_5.setEnabled(False)
@@ -53,6 +54,7 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         # self.form_proxy.cb_combined_bevel.setChecked()
 
         self.enable_signals(True)
+        self._suspend_proceed = False
 
     def _set_profile_combo_state(self):
         material = self.profile.Material
@@ -87,7 +89,12 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         self.profile.ViewObject.ShapeColor = (0.8, 0.2, 0.1)
 
     def reject(self):
-        App.ActiveDocument.abortTransaction()
+        self.profile.restoreContent(self.dump)
+        self.profile.recompute()
+        self.profile.ViewObject.Transparency = 0
+        self.profile.ViewObject.ShapeColor = (0.44, 0.47, 0.5)
+        App.ActiveDocument.commitTransaction()
+        App.ActiveDocument.recompute()
         Gui.ActiveDocument.resetEdit()
 
         return True

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -24,9 +24,7 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
 
         self.enable_signals(False)
 
-        self.form_proxy.combo_material.setCurrentText(self.profile.Material)
-        self.form_proxy.combo_family.setCurrentText(self.profile.Family)
-        self.form_proxy.combo_size.setCurrentText(self.profile.SizeName)
+        self._set_profile_combo_state()
 
         self.form_proxy.sb_width.setValue(self.profile.ProfileWidth)
         self.form_proxy.sb_height.setValue(self.profile.ProfileHeight)
@@ -56,12 +54,34 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
 
         self.enable_signals(True)
 
+    def _set_profile_combo_state(self):
+        material = self.profile.Material
+        family = self.profile.Family
+        size_name = self.profile.SizeName
+
+        self.form_proxy.combo_material.setCurrentText(material)
+
+        self.form_proxy.combo_family.clear()
+        self.form_proxy.combo_family.addItems([f for f in self.profiles.get(material, {})])
+        self.form_proxy.combo_family.setCurrentText(family)
+
+        family_profiles = self.profiles.get(material, {}).get(family, {})
+        self.form_proxy.combo_size.clear()
+        self.form_proxy.combo_size.addItems([s for s in family_profiles.get("sizes", {})])
+        self.form_proxy.combo_size.setCurrentText(size_name)
+
+        if family in self.profiles.get(material, {}):
+            family_data = self.profiles[material][family]
+            self.form_proxy.cb_make_fillet.setChecked(self.profile.MakeFillet)
+            self.form_proxy.cb_make_fillet.setEnabled(family_data["fillet"])
+            self.form_proxy.label_norm.setText(family_data["norm"])
+            self.form_proxy.label_unit.setText(family_data["unit"])
+            self.update_image()
+
     def open(self):
         App.ActiveDocument.openTransaction("Edit Profile")
 
         self.initialize_ui()
-
-        self.proceed()
 
         self.profile.ViewObject.Transparency = 50
         self.profile.ViewObject.ShapeColor = (0.8, 0.2, 0.1)

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -63,27 +63,15 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         size_name = self.profile.SizeName
 
         if material is None:
-            material = str(self.form_proxy.combo_material.currentText())
+            material = self.profile.Material
 
-        material_index = self.form_proxy.combo_material.findText(material)
-        if material_index >= 0:
-            self.form_proxy.combo_material.setCurrentIndex(material_index)
-        elif material:
-            self.form_proxy.combo_material.setCurrentText(material)
+        self._select_or_add_combo_text(self.form_proxy.combo_material, material)
 
         self.populate_family_combo(material)
-        family_index = self.form_proxy.combo_family.findText(family)
-        if family_index >= 0:
-            self.form_proxy.combo_family.setCurrentIndex(family_index)
-        else:
-            self.form_proxy.combo_family.setCurrentText(family)
+        self._select_or_add_combo_text(self.form_proxy.combo_family, family)
 
         self.populate_size_combo(material, family)
-        size_index = self.form_proxy.combo_size.findText(size_name)
-        if size_index >= 0:
-            self.form_proxy.combo_size.setCurrentIndex(size_index)
-        else:
-            self.form_proxy.combo_size.setCurrentText(size_name)
+        self._select_or_add_combo_text(self.form_proxy.combo_size, size_name)
 
         if material in self.profiles and family in self.profiles[material]:
             family_data = self.profiles[material][family]
@@ -92,6 +80,16 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
             self.form_proxy.label_norm.setText(family_data["norm"])
             self.form_proxy.label_unit.setText(family_data["unit"])
             self.update_image()
+
+    def _select_or_add_combo_text(self, combo, text):
+        if not text:
+            return
+
+        index = combo.findText(text)
+        if index < 0:
+            combo.addItem(text)
+            index = combo.findText(text)
+        combo.setCurrentIndex(index)
 
     def open(self):
         App.ActiveDocument.openTransaction("Edit Profile")

--- a/freecad/frameforge/edit_profile_tool.py
+++ b/freecad/frameforge/edit_profile_tool.py
@@ -19,7 +19,7 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
 
     def initialize_ui(self):
         self._suspend_proceed = True
-        super().initialize_ui()
+        super().initialize_ui(apply_defaults=False)
 
         self.form_proxy.groupBox_5.setEnabled(False)
 
@@ -40,6 +40,7 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         except:
             App.Console.PrintMessage(f"Frameforge : can't find Unit Price for {self.profile.Label}\n")
         self.form_proxy.cb_make_fillet.setChecked(self.profile.MakeFillet)
+        self.form_proxy.cb_pre_extend.setChecked(self._profile_has_pre_extend())
         if hasattr(self.profile, "AnchorX"):
             ax = ANCHOR_X.index(self.profile.AnchorX) if self.profile.AnchorX in ANCHOR_X else 1
             ay = ANCHOR_Y.index(self.profile.AnchorY) if self.profile.AnchorY in ANCHOR_Y else 1
@@ -57,22 +58,31 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         self._suspend_proceed = False
 
     def _set_profile_combo_state(self):
-        material = self.profile.Material
+        material = self.resolve_material_for_family(self.profile.Material, self.profile.Family)
         family = self.profile.Family
         size_name = self.profile.SizeName
 
-        self.form_proxy.combo_material.setCurrentText(material)
+        material_index = self.form_proxy.combo_material.findText(material)
+        if material_index >= 0:
+            self.form_proxy.combo_material.setCurrentIndex(material_index)
+        else:
+            self.form_proxy.combo_material.setCurrentText(material)
 
-        self.form_proxy.combo_family.clear()
-        self.form_proxy.combo_family.addItems([f for f in self.profiles.get(material, {})])
-        self.form_proxy.combo_family.setCurrentText(family)
+        self.populate_family_combo(material)
+        family_index = self.form_proxy.combo_family.findText(family)
+        if family_index >= 0:
+            self.form_proxy.combo_family.setCurrentIndex(family_index)
+        else:
+            self.form_proxy.combo_family.setCurrentText(family)
 
-        family_profiles = self.profiles.get(material, {}).get(family, {})
-        self.form_proxy.combo_size.clear()
-        self.form_proxy.combo_size.addItems([s for s in family_profiles.get("sizes", {})])
-        self.form_proxy.combo_size.setCurrentText(size_name)
+        self.populate_size_combo(material, family)
+        size_index = self.form_proxy.combo_size.findText(size_name)
+        if size_index >= 0:
+            self.form_proxy.combo_size.setCurrentIndex(size_index)
+        else:
+            self.form_proxy.combo_size.setCurrentText(size_name)
 
-        if family in self.profiles.get(material, {}):
+        if material in self.profiles and family in self.profiles[material]:
             family_data = self.profiles[material][family]
             self.form_proxy.cb_make_fillet.setChecked(self.profile.MakeFillet)
             self.form_proxy.cb_make_fillet.setEnabled(family_data["fillet"])
@@ -84,6 +94,8 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         App.ActiveDocument.openTransaction("Edit Profile")
 
         self.initialize_ui()
+
+        self.proceed()
 
         self.profile.ViewObject.Transparency = 50
         self.profile.ViewObject.ShapeColor = (0.8, 0.2, 0.1)
@@ -115,3 +127,7 @@ class EditProfileTaskPanel(BaseProfileTaskPanel):
         self.update_profile(self.profile)
 
         self.profile.recompute()
+
+    def _profile_has_pre_extend(self):
+        expected = max(self.profile.ProfileWidth, self.profile.ProfileHeight)
+        return abs(self.profile.OffsetA - expected) < 1e-7 and abs(self.profile.OffsetB - expected) < 1e-7

--- a/freecad/frameforge/profile.py
+++ b/freecad/frameforge/profile.py
@@ -280,6 +280,8 @@ class Profile:
         init_mirror_h=False,
         init_mirror_v=False,
         init_rotation=0.0,
+        init_offset_a=0.0,
+        init_offset_b=0.0,
     ):
         self.run_compatibility_migrations(obj)
 
@@ -325,9 +327,8 @@ class Profile:
         obj.MirrorH = bool(init_mirror_h)
         obj.MirrorV = bool(init_mirror_v)
         obj.RotationAngle = float(init_rotation)
-
-        # obj.OffsetA = .0  # Property for structure
-        # obj.OffsetB = .0  # Property for structure
+        obj.OffsetA = float(init_offset_a)
+        obj.OffsetB = float(init_offset_b)
 
     def on_changed(self, obj, p):
 
@@ -378,6 +379,7 @@ class Profile:
         R = obj.RadiusLarge
         r = obj.RadiusSmall
         d = vec(0, 0, 1)
+        p = None
 
         w = h = 0
 
@@ -1035,6 +1037,12 @@ class Profile:
                 p = tslot20x20_one_slot()
             else:
                 raise ValueError("T-Slot 1-Slot H/W")
+
+        if p is None:
+            raise ValueError(
+                f"Unsupported or unresolved profile family: material={obj.Material!r}, "
+                f"family={obj.Family!r}, size={obj.SizeName!r}"
+            )
 
         mirror_h = getattr(obj, "MirrorH", False)
         mirror_v = getattr(obj, "MirrorV", False)


### PR DESCRIPTION
## What was happening

Editing an existing profile could reopen the task panel with create-tool defaults instead of the values already stored on the selected object.

That made the edit flow unreliable: material, family, size, anchor, rotation, mirroring, and pre-extend could look stale or reset as soon as the dialog opened. In some cases, simply opening the edit dialog could also trigger an immediate write-back before the user changed anything.

A subtler version of the same bug appeared with legacy or ambiguous catalog data: if a stored family/size could not be resolved to exactly one material, the UI could fall back to the current default material and silently change the profile meaning on accept.

## How this fixes it

The edit dialog now rebuilds its state from the selected profile first, instead of replaying create-dialog defaults.

The task panel suspends live updates while the form is being populated, restores the profile's current settings before allowing `proceed()` to run, and avoids mutating the profile just by opening the dialog.

For catalog state, unresolved material/family/size values are preserved in the combo boxes rather than replaced with the current default. That keeps editing conservative: if FrameForge cannot prove which catalog entry owns the stored profile, it does not guess and rewrite it.

The create flow and saved preferences are intentionally unchanged.

## Validation

- `python3 -m py_compile freecad/frameforge/edit_profile_tool.py`
- `ruff check freecad/frameforge/edit_profile_tool.py`
- `git diff --check upstream/main...HEAD`
- Manual verification in FreeCAD on new and existing profile edits
