### PR TITLE
fix(ui): guard profile parent and reopen errors

### DIFF
--- a/freecad/frameforge/create_custom_profiles_tool.py
+++ b/freecad/frameforge/create_custom_profiles_tool.py
@@ -6,6 +6,7 @@ import FreeCAD as App
 import FreeCADGui as Gui
 from PySide import QtCore, QtGui
 
+from freecad.frameforge.create_profiles_tool import _move_to_parent_if_supported
 from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPATH, UIPATH, FormProxy, translate
 from freecad.frameforge.profile import Profile, ViewProviderCustomProfile
 
@@ -103,7 +104,7 @@ class CreateCustomProfileTaskPanel:
         # move it to the sketch's parent if possible
         if sketch is not None and len(sketch.Parents) > 0:
             sk_parent = sketch.Parents[-1][0]
-            sk_parent.addObject(obj)
+            _move_to_parent_if_supported(obj, sk_parent)
 
         if sketch is not None and edge is not None:
             # Tuple assignment for edge

--- a/freecad/frameforge/create_profiles_tool.py
+++ b/freecad/frameforge/create_profiles_tool.py
@@ -12,6 +12,15 @@ from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPA
 from freecad.frameforge.profile import Profile, ViewProviderProfile
 
 
+def _move_to_parent_if_supported(obj, parent):
+    try:
+        parent.addObject(obj)
+    except ValueError:
+        App.Console.PrintMessage(
+            f"Frameforge: parent {parent.Label} ({parent.TypeId}) does not accept {obj.TypeId}, keeping at document root\n"
+        )
+
+
 class BaseProfileTaskPanel(ABC):
     def __init__(self):
         self._objects = {}
@@ -479,7 +488,7 @@ class CreateProfileTaskPanel(BaseProfileTaskPanel):
         # move it to the sketch's parent if possible
         if sketch is not None and len(sketch.Parents) > 0:
             sk_parent = sketch.Parents[-1][0]
-            sk_parent.addObject(obj)
+            _move_to_parent_if_supported(obj, sk_parent)
 
         if sketch is not None and edge is not None:
             # Tuple assignment for edge

--- a/freecad/frameforge/profile.py
+++ b/freecad/frameforge/profile.py
@@ -1692,7 +1692,7 @@ class ViewProviderProfile:
         return True
 
     def edit(self):
-        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
+        Gui.ActiveDocument.setEdit(self.Object, 0)
 
 
 class ViewProviderCustomProfile(ViewProviderProfile):

--- a/freecad/frameforge/profile.py
+++ b/freecad/frameforge/profile.py
@@ -1673,7 +1673,10 @@ class ViewProviderProfile:
         import freecad.frameforge.edit_profile_tool
 
         if Gui.Control.activeDialog():
-            Gui.Control.closeDialog()
+            App.Console.PrintMessage(
+                "Frameforge: another task dialog is already open; close it before editing this profile.\n"
+            )
+            return False
 
         taskd = freecad.frameforge.edit_profile_tool.EditProfileTaskPanel(self.Object)
         Gui.Control.showDialog(taskd)

--- a/freecad/frameforge/profile.py
+++ b/freecad/frameforge/profile.py
@@ -39,6 +39,17 @@ FLANGE_ANGLES = {
 
 # Global variable for a 3D float vector (used in Profile class)
 vec = App.Base.Vector
+EDGE_EPSILON = 1e-7
+
+
+def _line_if_distinct(start, end):
+    if start.distanceToPoint(end) <= EDGE_EPSILON:
+        return None
+    return Part.makeLine(start, end)
+
+
+def _compact_edges(*edges):
+    return [edge for edge in edges if edge is not None]
 
 
 class Profile:
@@ -470,17 +481,17 @@ class Profile:
                 c2 = vec(TW + R + w, TW + R + h, 0)
                 c3 = vec(W - r + w, TW - r + h, 0)
 
-                L1 = Part.makeLine(p1, p2)
-                L2 = Part.makeLine(p2, p3)
-                L3 = Part.makeLine(p4, p5)
-                L4 = Part.makeLine(p6, p7)
-                L5 = Part.makeLine(p8, p9)
-                L6 = Part.makeLine(p9, p1)
+                L1 = _line_if_distinct(p1, p2)
+                L2 = _line_if_distinct(p2, p3)
+                L3 = _line_if_distinct(p4, p5)
+                L4 = _line_if_distinct(p6, p7)
+                L5 = _line_if_distinct(p8, p9)
+                L6 = _line_if_distinct(p9, p1)
                 A1 = Part.makeCircle(r, c1, d, 0, 90)
                 A2 = Part.makeCircle(R, c2, d, 180, 270)
                 A3 = Part.makeCircle(r, c3, d, 0, 90)
 
-                wire1 = Part.Wire([L1, L2, A1, L3, A2, L4, A3, L5, L6])
+                wire1 = Part.Wire(_compact_edges(L1, L2, A1, L3, A2, L4, A3, L5, L6))
 
             p = Part.Face(wire1)
 
@@ -540,16 +551,16 @@ class Profile:
                 c3 = vec(W - R + w, H - R + h, 0)
                 c4 = vec(W - R + w, R + h, 0)
 
-                L1 = Part.makeLine(p1, p2)
-                L2 = Part.makeLine(p3, p4)
-                L3 = Part.makeLine(p5, p6)
-                L4 = Part.makeLine(p7, p8)
+                L1 = _line_if_distinct(p1, p2)
+                L2 = _line_if_distinct(p3, p4)
+                L3 = _line_if_distinct(p5, p6)
+                L4 = _line_if_distinct(p7, p8)
                 A1 = Part.makeCircle(R, c1, d, 180, 270)
                 A2 = Part.makeCircle(R, c2, d, 90, 180)
                 A3 = Part.makeCircle(R, c3, d, 0, 90)
                 A4 = Part.makeCircle(R, c4, d, 270, 0)
 
-                wire1 = Part.Wire([L1, A2, L2, A3, L3, A4, L4, A1])
+                wire1 = Part.Wire(_compact_edges(L1, A2, L2, A3, L3, A4, L4, A1))
 
                 p1 = vec(TW + w, TW + r + h, 0)
                 p2 = vec(TW + w, H - TW - r + h, 0)
@@ -565,16 +576,16 @@ class Profile:
                 c3 = vec(W - TW - r + w, H - TW - r + h, 0)
                 c4 = vec(W - TW - r + w, TW + r + h, 0)
 
-                L1 = Part.makeLine(p1, p2)
-                L2 = Part.makeLine(p3, p4)
-                L3 = Part.makeLine(p5, p6)
-                L4 = Part.makeLine(p7, p8)
+                L1 = _line_if_distinct(p1, p2)
+                L2 = _line_if_distinct(p3, p4)
+                L3 = _line_if_distinct(p5, p6)
+                L4 = _line_if_distinct(p7, p8)
                 A1 = Part.makeCircle(r, c1, d, 180, 270)
                 A2 = Part.makeCircle(r, c2, d, 90, 180)
                 A3 = Part.makeCircle(r, c3, d, 0, 90)
                 A4 = Part.makeCircle(r, c4, d, 270, 0)
 
-                wire2 = Part.Wire([L1, A2, L2, A3, L3, A4, L4, A1])
+                wire2 = Part.Wire(_compact_edges(L1, A2, L2, A3, L3, A4, L4, A1))
 
             if wire2:
                 p1 = Part.Face(wire1)
@@ -1660,6 +1671,9 @@ class ViewProviderProfile:
             return None
 
         import freecad.frameforge.edit_profile_tool
+
+        if Gui.Control.activeDialog():
+            Gui.Control.closeDialog()
 
         taskd = freecad.frameforge.edit_profile_tool.EditProfileTaskPanel(self.Object)
         Gui.Control.showDialog(taskd)


### PR DESCRIPTION
## What was happening

There were a few related failure paths around profile creation and reopening the task dialog.

Creating a profile from a sketch inside a `PartDesign::Body` could raise `ValueError: Body: object is not allowed` when FrameForge tried to move the new profile object under the sketch parent.

Reopening profile edit could also fail with `RuntimeError: Active task dialog found` if a previous task dialog was still active. The first guard for that avoided the traceback, but it was too broad because it closed whichever task dialog happened to be active.

Some filleted profile shapes could also hit OCC errors like `gp_Dir2d() - input vector has zero norm` when the generated wire contained zero-length straight segments.

## How this fixes it

This change makes profile creation and reopening more defensive in three places.

- When a sketch parent does not accept the created profile object, FrameForge now leaves the object at the document root instead of raising and aborting creation.
- When another task dialog is active, FrameForge now reports that state and refuses to open a second edit dialog instead of closing an unrelated dialog behind the user's back.
- The filleted wire builders now skip degenerate line segments before constructing the final wire, which avoids feeding zero-length edges into OCC.

These changes are intentionally narrow: they do not change the create/edit workflow semantics beyond making these failure cases recover safely.

## Validation

- `python3 -m py_compile freecad/frameforge/profile.py`
- `ruff check --select F821 freecad/frameforge/profile.py`
- `git diff --check upstream/main...HEAD`
- Manual verification in FreeCAD for profile creation under body-owned sketches, reopening edit dialogs, and filleted profile updates
