### PR TITLE
fix(migration): harden legacy profile recovery on FreeCAD 1.1

### DIFF
--- a/freecad/frameforge/_utils.py
+++ b/freecad/frameforge/_utils.py
@@ -120,6 +120,69 @@ def is_part_or_part_design(obj):
     return obj.TypeId.startswith(("Part::", "PartDesign::"))
 
 
+def ensure_property(obj, prop_type, name, group, description="", default=None, editor_mode=None):
+    if not hasattr(obj, name):
+        obj.addProperty(prop_type, name, group, description)
+        if default is not None:
+            setattr(obj, name, default)
+    if editor_mode is not None:
+        obj.setEditorMode(name, editor_mode)
+
+
+def ensure_profile_structure_properties(obj, cutout):
+    ensure_property(obj, "App::PropertyString", "PID", "Profile", "Profile ID", "", 1)
+    ensure_property(obj, "App::PropertyString", "Family", "Profile", "", editor_mode=1)
+    ensure_property(obj, "App::PropertyLink", "CustomProfile", "Profile", "Target profile", None, 1)
+    ensure_property(obj, "App::PropertyString", "SizeName", "Profile", "", editor_mode=1)
+    ensure_property(obj, "App::PropertyString", "Material", "Profile", "", editor_mode=1)
+    ensure_property(
+        obj,
+        "App::PropertyFloat",
+        "ApproxWeight",
+        "Base",
+        "Approximate weight in Kilogram",
+        editor_mode=1,
+    )
+    ensure_property(obj, "App::PropertyFloat", "Price", "Base", "Profile Price", editor_mode=1)
+    ensure_property(obj, "App::PropertyLength", "Width", "Structure", "Parameter for structure", editor_mode=1)
+    ensure_property(obj, "App::PropertyLength", "Height", "Structure", "Parameter for structure", editor_mode=1)
+    ensure_property(obj, "App::PropertyLength", "Length", "Structure", "Parameter for structure", editor_mode=1)
+    ensure_property(obj, "App::PropertyBool", "Cutout", "Structure", "Has Cutout", cutout, 1)
+    obj.Cutout = cutout
+    ensure_property(obj, "App::PropertyString", "CuttingAngleA", "Structure", "Cutting Angle A", editor_mode=1)
+    ensure_property(obj, "App::PropertyString", "CuttingAngleB", "Structure", "Cutting Angle B", editor_mode=1)
+
+
+def copy_profile_structure_data(obj, profile):
+    required = (
+        "ProfileWidth",
+        "ProfileHeight",
+        "Family",
+        "SizeName",
+        "Material",
+        "ApproxWeight",
+        "Price",
+    )
+    missing = [name for name in required if not hasattr(profile, name)]
+    if missing:
+        FreeCAD.Console.PrintError(
+            "Frameforge: cannot update structure data from "
+            f"{getattr(profile, 'Label', profile)}; missing {', '.join(missing)}\n"
+        )
+        return False
+
+    obj.PID = str(getattr(profile, "PID", ""))
+    obj.Width = profile.ProfileWidth
+    obj.Height = profile.ProfileHeight
+    obj.Family = profile.Family
+    obj.CustomProfile = getattr(profile, "CustomProfile", None)
+    obj.SizeName = profile.SizeName
+    obj.Material = profile.Material
+    obj.ApproxWeight = profile.ApproxWeight
+    obj.Price = profile.Price
+    return True
+
+
 def get_profiles_and_links_from_object(profiles, links, obj):
     if is_fusion(obj):
         for child in obj.Shapes:

--- a/freecad/frameforge/_utils.py
+++ b/freecad/frameforge/_utils.py
@@ -385,8 +385,6 @@ def length_along_normal(obj):
 
 def get_readable_cutting_angles(ba_y, ba_x, bb_y, bb_x, *trim_cuts):
     all_bevels = [ba_y, ba_x, bb_y, bb_x]
-    start_bevels = [ba_y, ba_x]
-    end_bevels = [bb_y, bb_x]
 
     if len(trim_cuts) == 0:
         # a real profile

--- a/freecad/frameforge/extruded_cutout.py
+++ b/freecad/frameforge/extruded_cutout.py
@@ -8,6 +8,9 @@ import Part
 from PySide import QtCore, QtGui
 
 from freecad.frameforge._utils import (
+    copy_profile_structure_data,
+    ensure_property,
+    ensure_profile_structure_properties,
     get_childrens_from_extrudedcutout,
     get_profile_from_extrudedcutout,
     get_readable_cutting_angles,
@@ -184,15 +187,8 @@ class ExtrudedCutout:
         else:
             angles = ()
 
-        obj.PID = str(getattr(prof, "PID", ""))
-        obj.Width = prof.ProfileWidth
-        obj.Height = prof.ProfileHeight
-        obj.Family = prof.Family
-        obj.CustomProfile = prof.CustomProfile
-        obj.SizeName = prof.SizeName
-        obj.Material = prof.Material
-        obj.ApproxWeight = prof.ApproxWeight
-        obj.Price = prof.Price
+        if not copy_profile_structure_data(obj, prof):
+            return
 
         obj.Length = length_along_normal(trim_prof if trim_prof else prof)
 
@@ -214,71 +210,26 @@ class ExtrudedCutout:
             if proxy is not None and hasattr(proxy, "execute"):
                 proxy.execute(base_obj)
             else:
+                label = getattr(base_obj, "Label", base_obj)
                 App.Console.PrintMessage(
-                    f"Frameforge: skipping proxy execution for {getattr(base_obj, 'Label', base_obj)} because no executable Proxy is available\n"
+                    f"Frameforge: skipping proxy execution for {label} because no executable Proxy is available\n"
                 )
 
             App.Console.PrintMessage(f"Frameforge::object migration : Migrate {obj.Label} to 0.1.8\n")
 
             # related to Profile
-            obj.addProperty(
-                "App::PropertyString",
-                "PID",
-                "Profile",
-                "Profile ID",
-            ).PID = ""
-            obj.setEditorMode("PID", 1)
-
-            obj.addProperty("App::PropertyString", "Family", "Profile", "")
-            obj.setEditorMode("Family", 1)
-
-            obj.addProperty("App::PropertyLink", "CustomProfile", "Profile", "Target profile").CustomProfile = None
-            obj.setEditorMode("CustomProfile", 1)
-
-            obj.addProperty("App::PropertyString", "SizeName", "Profile", "")
-            obj.setEditorMode("SizeName", 1)
-
-            obj.addProperty("App::PropertyString", "Material", "Profile", "")
-            obj.setEditorMode("Material", 1)
-
-            obj.addProperty("App::PropertyFloat", "ApproxWeight", "Base", "Approximate weight in Kilogram")
-            obj.setEditorMode("ApproxWeight", 1)
-
-            obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price")
-            obj.setEditorMode("Price", 1)
-
-            # structure
-            obj.addProperty("App::PropertyLength", "Width", "Structure", "Parameter for structure")
-            obj.addProperty("App::PropertyLength", "Height", "Structure", "Parameter for structure")
-            obj.addProperty("App::PropertyLength", "Length", "Structure", "Parameter for structure")
-            obj.addProperty("App::PropertyBool", "Cutout", "Structure", "Has Cutout").Cutout = True
-            obj.setEditorMode("Width", 1)  # user doesn't change !
-            obj.setEditorMode("Height", 1)
-            obj.setEditorMode("Length", 1)
-            obj.setEditorMode("Cutout", 1)
-
-            obj.addProperty(
-                "App::PropertyString",
-                "CuttingAngleA",
-                "Structure",
-                "Cutting Angle A",
-            )
-            obj.setEditorMode("CuttingAngleA", 1)
-            obj.addProperty(
-                "App::PropertyString",
-                "CuttingAngleB",
-                "Structure",
-                "Cutting Angle B",
-            )
-            obj.setEditorMode("CuttingAngleB", 1)
+            ensure_profile_structure_properties(obj, cutout=True)
 
             # add version
-            obj.addProperty(
+            ensure_property(
+                obj,
                 "App::PropertyString",
                 "FrameforgeVersion",
                 "Profile",
                 "Frameforge Version used to create the profile",
-            ).FrameforgeVersion = ff_version
+                ff_version,
+            )
+            obj.FrameforgeVersion = ff_version
 
 
 class ViewProviderExtrudedCutout:

--- a/freecad/frameforge/extruded_cutout.py
+++ b/freecad/frameforge/extruded_cutout.py
@@ -1,11 +1,6 @@
-import glob
-import math
-import os
-
 import FreeCAD as App
 import FreeCADGui as Gui
 import Part
-from PySide import QtCore, QtGui
 
 from freecad.frameforge._utils import (
     copy_profile_structure_data,
@@ -18,7 +13,7 @@ from freecad.frameforge._utils import (
     get_trimmedprofile_from_extrudedcutout,
     length_along_normal,
 )
-from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPATH, UIPATH, translate
+from freecad.frameforge.ff_tools import translate
 from freecad.frameforge.frameforge_exceptions import FrameForgeException
 from freecad.frameforge.version import __version__ as ff_version
 
@@ -314,7 +309,7 @@ class ViewProviderExtrudedCutout:
         return True
 
     def edit(self):
-        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
+        Gui.ActiveDocument.setEdit(self.Object, 0)
 
     def getIcon(self):
         return """

--- a/freecad/frameforge/extruded_cutout.py
+++ b/freecad/frameforge/extruded_cutout.py
@@ -184,7 +184,7 @@ class ExtrudedCutout:
         else:
             angles = ()
 
-        obj.PID = prof.PID
+        obj.PID = str(getattr(prof, "PID", ""))
         obj.Width = prof.ProfileWidth
         obj.Height = prof.ProfileHeight
         obj.Family = prof.Family
@@ -209,7 +209,14 @@ class ExtrudedCutout:
 
     def run_compatibility_migrations(self, obj):
         if not hasattr(obj, "FrameforgeVersion"):
-            obj.baseObject[0].Proxy.execute(obj.baseObject[0])
+            base_obj = obj.baseObject[0]
+            proxy = getattr(base_obj, "Proxy", None)
+            if proxy is not None and hasattr(proxy, "execute"):
+                proxy.execute(base_obj)
+            else:
+                App.Console.PrintMessage(
+                    f"Frameforge: skipping proxy execution for {getattr(base_obj, 'Label', base_obj)} because no executable Proxy is available\n"
+                )
 
             App.Console.PrintMessage(f"Frameforge::object migration : Migrate {obj.Label} to 0.1.8\n")
 

--- a/freecad/frameforge/profile.py
+++ b/freecad/frameforge/profile.py
@@ -1506,8 +1506,17 @@ class ViewProviderProfile:
         if not obj or not hasattr(obj, "Target") or not obj.Target:
             return
 
-        edge = obj.Target[0].getSubObject(obj.Target[1][0])
-        p1 = edge.Vertexes[1].Point
+        try:
+            edge = obj.Target[0].getSubObject(obj.Target[1][0])
+        except Exception as exc:
+            App.Console.PrintMessage(f"Frameforge: unable to resolve target edge for {obj.Label}: {exc}\n")
+            return
+
+        if not hasattr(edge, "Vertexes") or len(edge.Vertexes) < 2:
+            App.Console.PrintMessage(f"Frameforge: target edge for {obj.Label} has insufficient vertices\n")
+            return
+
+        p1 = edge.Vertexes[-1].Point
         p2 = edge.Vertexes[0].Point
 
         # Local coordinates

--- a/freecad/frameforge/trimmed_profile.py
+++ b/freecad/frameforge/trimmed_profile.py
@@ -20,6 +20,16 @@ from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPA
 from freecad.frameforge.version import __version__ as ff_version
 
 
+def _execute_proxy_if_available(obj):
+    proxy = getattr(obj, "Proxy", None)
+    if proxy is not None and hasattr(proxy, "execute"):
+        proxy.execute(obj)
+        return
+    App.Console.PrintMessage(
+        f"Frameforge: skipping proxy execution for {getattr(obj, 'Label', obj)} because no executable Proxy is available\n"
+    )
+
+
 class TrimmedProfile:
     def __init__(self, obj):
         obj.addProperty(
@@ -208,7 +218,7 @@ class TrimmedProfile:
         prof = get_profile_from_trimmedbody(obj)
         angles = get_trimmed_profile_all_cutting_angles(obj)
 
-        obj.PID = prof.PID
+        obj.PID = str(getattr(prof, "PID", ""))
         obj.Width = prof.ProfileWidth
         obj.Height = prof.ProfileHeight
         obj.Family = prof.Family
@@ -235,62 +245,76 @@ class TrimmedProfile:
         if not hasattr(obj, "FrameforgeVersion"):
             # migrate parents
             for link in obj.TrimmingBoundary:
-                link[0].Proxy.execute(link[0])
-            obj.TrimmedBody.Proxy.execute(obj.TrimmedBody)
+                _execute_proxy_if_available(link[0])
+            if obj.TrimmedBody is not None:
+                _execute_proxy_if_available(obj.TrimmedBody)
 
             App.Console.PrintMessage(f"Frameforge::object migration : Migrate {obj.Label} to 0.1.8\n")
 
             # related to Profile
-            obj.addProperty(
-                "App::PropertyString",
-                "PID",
-                "Profile",
-                "Profile ID",
-            ).PID = ""
-            obj.setEditorMode("PID", 1)
+            if not hasattr(obj, "PID"):
+                obj.addProperty(
+                    "App::PropertyString",
+                    "PID",
+                    "Profile",
+                    "Profile ID",
+                ).PID = ""
+                obj.setEditorMode("PID", 1)
 
-            obj.addProperty("App::PropertyString", "Family", "Profile", "")
-            obj.setEditorMode("Family", 1)
+            if not hasattr(obj, "Family"):
+                obj.addProperty("App::PropertyString", "Family", "Profile", "")
+                obj.setEditorMode("Family", 1)
 
-            obj.addProperty("App::PropertyLink", "CustomProfile", "Profile", "Target profile").CustomProfile = None
-            obj.setEditorMode("CustomProfile", 1)
+            if not hasattr(obj, "CustomProfile"):
+                obj.addProperty("App::PropertyLink", "CustomProfile", "Profile", "Target profile").CustomProfile = None
+                obj.setEditorMode("CustomProfile", 1)
 
-            obj.addProperty("App::PropertyString", "SizeName", "Profile", "")
-            obj.setEditorMode("SizeName", 1)
+            if not hasattr(obj, "SizeName"):
+                obj.addProperty("App::PropertyString", "SizeName", "Profile", "")
+                obj.setEditorMode("SizeName", 1)
 
-            obj.addProperty("App::PropertyString", "Material", "Profile", "")
-            obj.setEditorMode("Material", 1)
+            if not hasattr(obj, "Material"):
+                obj.addProperty("App::PropertyString", "Material", "Profile", "")
+                obj.setEditorMode("Material", 1)
 
-            obj.addProperty("App::PropertyFloat", "ApproxWeight", "Base", "Approximate weight in Kilogram")
-            obj.setEditorMode("ApproxWeight", 1)
+            if not hasattr(obj, "ApproxWeight"):
+                obj.addProperty("App::PropertyFloat", "ApproxWeight", "Base", "Approximate weight in Kilogram")
+                obj.setEditorMode("ApproxWeight", 1)
 
-            obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price")
-            obj.setEditorMode("Price", 1)
+            if not hasattr(obj, "Price"):
+                obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price")
+                obj.setEditorMode("Price", 1)
 
             # structure
-            obj.addProperty("App::PropertyLength", "Width", "Structure", "Parameter for structure")
-            obj.addProperty("App::PropertyLength", "Height", "Structure", "Parameter for structure")
-            obj.addProperty("App::PropertyLength", "Length", "Structure", "Parameter for structure")
-            obj.addProperty("App::PropertyBool", "Cutout", "Structure", "Has Cutout").Cutout = False
-            obj.setEditorMode("Width", 1)  # user doesn't change !
-            obj.setEditorMode("Height", 1)
-            obj.setEditorMode("Length", 1)
-            obj.setEditorMode("Cutout", 1)
+            if not hasattr(obj, "Width"):
+                obj.addProperty("App::PropertyLength", "Width", "Structure", "Parameter for structure")
+                obj.setEditorMode("Width", 1)
+            if not hasattr(obj, "Height"):
+                obj.addProperty("App::PropertyLength", "Height", "Structure", "Parameter for structure")
+                obj.setEditorMode("Height", 1)
+            if not hasattr(obj, "Length"):
+                obj.addProperty("App::PropertyLength", "Length", "Structure", "Parameter for structure")
+                obj.setEditorMode("Length", 1)
+            if not hasattr(obj, "Cutout"):
+                obj.addProperty("App::PropertyBool", "Cutout", "Structure", "Has Cutout").Cutout = False
+                obj.setEditorMode("Cutout", 1)
 
-            obj.addProperty(
-                "App::PropertyString",
-                "CuttingAngleA",
-                "Structure",
-                "Cutting Angle A",
-            )
-            obj.setEditorMode("CuttingAngleA", 1)
-            obj.addProperty(
-                "App::PropertyString",
-                "CuttingAngleB",
-                "Structure",
-                "Cutting Angle B",
-            )
-            obj.setEditorMode("CuttingAngleB", 1)
+            if not hasattr(obj, "CuttingAngleA"):
+                obj.addProperty(
+                    "App::PropertyString",
+                    "CuttingAngleA",
+                    "Structure",
+                    "Cutting Angle A",
+                )
+                obj.setEditorMode("CuttingAngleA", 1)
+            if not hasattr(obj, "CuttingAngleB"):
+                obj.addProperty(
+                    "App::PropertyString",
+                    "CuttingAngleB",
+                    "Structure",
+                    "Cutting Angle B",
+                )
+                obj.setEditorMode("CuttingAngleB", 1)
 
             # add version
             obj.addProperty(

--- a/freecad/frameforge/trimmed_profile.py
+++ b/freecad/frameforge/trimmed_profile.py
@@ -1,13 +1,10 @@
-import glob
 import math
-import os
 
 import ArchCommands
 import BOPTools.SplitAPI
 import FreeCAD as App
 import FreeCADGui as Gui
 import Part
-from PySide import QtCore, QtGui
 
 from freecad.frameforge._utils import (
     copy_profile_structure_data,
@@ -19,7 +16,7 @@ from freecad.frameforge._utils import (
     get_trimmed_profile_all_cutting_angles,
     length_along_normal,
 )
-from freecad.frameforge.ff_tools import ICONPATH, PROFILEIMAGES_PATH, PROFILESPATH, UIPATH, translate
+from freecad.frameforge.ff_tools import translate
 from freecad.frameforge.version import __version__ as ff_version
 
 
@@ -395,4 +392,4 @@ class ViewProviderTrimmedProfile:
         return True
 
     def edit(self):
-        FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
+        Gui.ActiveDocument.setEdit(self.Object, 0)

--- a/freecad/frameforge/trimmed_profile.py
+++ b/freecad/frameforge/trimmed_profile.py
@@ -10,6 +10,9 @@ import Part
 from PySide import QtCore, QtGui
 
 from freecad.frameforge._utils import (
+    copy_profile_structure_data,
+    ensure_property,
+    ensure_profile_structure_properties,
     get_childrens_from_trimmedbody,
     get_profile_from_trimmedbody,
     get_readable_cutting_angles,
@@ -25,8 +28,9 @@ def _execute_proxy_if_available(obj):
     if proxy is not None and hasattr(proxy, "execute"):
         proxy.execute(obj)
         return
+    label = getattr(obj, "Label", obj)
     App.Console.PrintMessage(
-        f"Frameforge: skipping proxy execution for {getattr(obj, 'Label', obj)} because no executable Proxy is available\n"
+        f"Frameforge: skipping proxy execution for {label} because no executable Proxy is available\n"
     )
 
 
@@ -218,15 +222,8 @@ class TrimmedProfile:
         prof = get_profile_from_trimmedbody(obj)
         angles = get_trimmed_profile_all_cutting_angles(obj)
 
-        obj.PID = str(getattr(prof, "PID", ""))
-        obj.Width = prof.ProfileWidth
-        obj.Height = prof.ProfileHeight
-        obj.Family = prof.Family
-        obj.CustomProfile = prof.CustomProfile
-        obj.SizeName = prof.SizeName
-        obj.Material = prof.Material
-        obj.ApproxWeight = prof.ApproxWeight
-        obj.Price = prof.Price
+        if not copy_profile_structure_data(obj, prof):
+            return
 
         obj.Length = length_along_normal(obj)
 
@@ -252,77 +249,18 @@ class TrimmedProfile:
             App.Console.PrintMessage(f"Frameforge::object migration : Migrate {obj.Label} to 0.1.8\n")
 
             # related to Profile
-            if not hasattr(obj, "PID"):
-                obj.addProperty(
-                    "App::PropertyString",
-                    "PID",
-                    "Profile",
-                    "Profile ID",
-                ).PID = ""
-                obj.setEditorMode("PID", 1)
-
-            if not hasattr(obj, "Family"):
-                obj.addProperty("App::PropertyString", "Family", "Profile", "")
-                obj.setEditorMode("Family", 1)
-
-            if not hasattr(obj, "CustomProfile"):
-                obj.addProperty("App::PropertyLink", "CustomProfile", "Profile", "Target profile").CustomProfile = None
-                obj.setEditorMode("CustomProfile", 1)
-
-            if not hasattr(obj, "SizeName"):
-                obj.addProperty("App::PropertyString", "SizeName", "Profile", "")
-                obj.setEditorMode("SizeName", 1)
-
-            if not hasattr(obj, "Material"):
-                obj.addProperty("App::PropertyString", "Material", "Profile", "")
-                obj.setEditorMode("Material", 1)
-
-            if not hasattr(obj, "ApproxWeight"):
-                obj.addProperty("App::PropertyFloat", "ApproxWeight", "Base", "Approximate weight in Kilogram")
-                obj.setEditorMode("ApproxWeight", 1)
-
-            if not hasattr(obj, "Price"):
-                obj.addProperty("App::PropertyFloat", "Price", "Base", "Profile Price")
-                obj.setEditorMode("Price", 1)
-
-            # structure
-            if not hasattr(obj, "Width"):
-                obj.addProperty("App::PropertyLength", "Width", "Structure", "Parameter for structure")
-                obj.setEditorMode("Width", 1)
-            if not hasattr(obj, "Height"):
-                obj.addProperty("App::PropertyLength", "Height", "Structure", "Parameter for structure")
-                obj.setEditorMode("Height", 1)
-            if not hasattr(obj, "Length"):
-                obj.addProperty("App::PropertyLength", "Length", "Structure", "Parameter for structure")
-                obj.setEditorMode("Length", 1)
-            if not hasattr(obj, "Cutout"):
-                obj.addProperty("App::PropertyBool", "Cutout", "Structure", "Has Cutout").Cutout = False
-                obj.setEditorMode("Cutout", 1)
-
-            if not hasattr(obj, "CuttingAngleA"):
-                obj.addProperty(
-                    "App::PropertyString",
-                    "CuttingAngleA",
-                    "Structure",
-                    "Cutting Angle A",
-                )
-                obj.setEditorMode("CuttingAngleA", 1)
-            if not hasattr(obj, "CuttingAngleB"):
-                obj.addProperty(
-                    "App::PropertyString",
-                    "CuttingAngleB",
-                    "Structure",
-                    "Cutting Angle B",
-                )
-                obj.setEditorMode("CuttingAngleB", 1)
+            ensure_profile_structure_properties(obj, cutout=False)
 
             # add version
-            obj.addProperty(
+            ensure_property(
+                obj,
                 "App::PropertyString",
                 "FrameforgeVersion",
                 "Profile",
                 "Frameforge Version used to create the profile",
-            ).FrameforgeVersion = ff_version
+                ff_version,
+            )
+            obj.FrameforgeVersion = ff_version
 
     def getOutsideCV(self, cutplane, shape):
         cv = ArchCommands.getCutVolume(cutplane, shape, clip=False, depth=0.0)


### PR DESCRIPTION
Closes #119

## What was happening

Older FrameForge documents could fail badly when opened on newer setups, especially around profile-derived objects that had partially migrated state.

The migration path assumed linked objects still had a live FrameForge `Proxy`, assumed helper target edges could always be resolved cleanly, copied older `PID` values without normalizing them, and duplicated profile metadata migration logic between trimmed profiles and extruded cutouts. In practice that could surface as migration-time exceptions, broken trimmed profiles, and helper updates that failed before the document could settle into a recoverable state.

## How this changes it

This patch makes the legacy recovery path more defensive instead of assuming every linked object is already healthy.

- Guard proxy execution during migration so older or downgraded linked objects do not immediately crash the migration pass.
- Normalize copied `PID` values to strings when rebuilding trimmed profiles and extruded cutouts.
- Share the property-creation and metadata-copying path for trimmed profiles and extruded cutouts, so partial migrations behave consistently.
- Make the profile view helper bail out cleanly when an old target edge cannot be resolved or no longer has enough vertices.
- Avoid re-adding migration properties that already exist, which reduces the chance of secondary failures in partially migrated documents.

The goal is not to fully redesign migration logic. It is to let older documents recover far enough to open, recompute, and be repaired instead of failing on the first invalid assumption.

## Validation

- `python3 -m py_compile freecad/frameforge/_utils.py freecad/frameforge/trimmed_profile.py freecad/frameforge/extruded_cutout.py`
- `ruff check freecad/frameforge/_utils.py freecad/frameforge/trimmed_profile.py freecad/frameforge/extruded_cutout.py`
- `git diff --check upstream/main...HEAD`

## Notes

This still needs validation against a real legacy `.FCStd` reproduction file from the issue report. There is no FreeCAD runtime available in this shell, so the checks here are limited to static validation and code-path hardening.
